### PR TITLE
Add support for audio effect plugin types (and other CLAP "features")

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ function(clap_juce_extensions_plugin)
     set(CJA_CLAP_FEATURES instrument)
   endif()
 
-  # Parsing CLAP_FEATURES (this is a little messy...)
+  # Parse CLAP_FEATURES into a comma-separated strings (is there an easier way to do this?)
   set(CJA_CLAP_FEATURES_PARSED "")
   foreach(FEATURE IN LISTS CJA_CLAP_FEATURES)
     set(CJA_CLAP_FEATURES_PARSED "${CJA_CLAP_FEATURES_PARSED}\"${FEATURE}\",")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,15 @@ function(clap_juce_extensions_plugin)
 
   if ("${CJA_CLAP_FEATURES}" STREQUAL "")
     message(WARNING "No CLAP_FEATURES were specified! Using \"instrument\" by default.")
-    set(CJA_CLAP_FEATURES "instrument")
+    set(CJA_CLAP_FEATURES instrument)
   endif()
+
+  # Parsing CLAP_FEATURES (this is a little messy...)
+  set(CJA_CLAP_FEATURES_PARSED "")
+  foreach(FEATURE IN LISTS CJA_CLAP_FEATURES)
+    set(CJA_CLAP_FEATURES_PARSED "${CJA_CLAP_FEATURES_PARSED}\"${FEATURE}\",")
+  endforeach()
+  STRING(REGEX REPLACE "(,)[^,]*$" "" CJA_CLAP_FEATURES_PARSED ${CJA_CLAP_FEATURES_PARSED}) # strip trailing comma
 
   get_property(SRC TARGET clap_juce_sources PROPERTY SOURCES)
   add_library(${claptarget} MODULE ${SRC})
@@ -85,7 +92,7 @@ function(clap_juce_extensions_plugin)
 
   target_compile_definitions(${claptarget} PRIVATE
           CLAP_ID="${CJA_CLAP_ID}"
-          CLAP_FEATURES=${CJA_CLAP_FEATURES}
+          CLAP_FEATURES=${CJA_CLAP_FEATURES_PARSED}
           CLAP_MANUAL_URL="${CJA_CLAP_MANUAL_URL}"
           CLAP_SUPPORT_URL="${CJA_CLAP_SUPPORT_URL}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(clap_juce_sources INTERFACE ${CMAKE_CURRENT_SOURCE_DI
 
 function(clap_juce_extensions_plugin)
   set(oneValueArgs TARGET)
-  set(multiValueArgs CLAP_ID CLAP_MANUAL_URL CLAP_SUPPORT_URL)
+  set(multiValueArgs CLAP_ID CLAP_FEATURES CLAP_MANUAL_URL CLAP_SUPPORT_URL)
 
   cmake_parse_arguments(CJA "" "${oneValueArgs}"
           "${multiValueArgs}" ${ARGN} )
@@ -46,6 +46,11 @@ function(clap_juce_extensions_plugin)
 
   if ("${CJA_CLAP_ID}" STREQUAL "")
     message(FATAL_ERROR "You must specify CLAP_ID to add a clap" )
+  endif()
+
+  if ("${CJA_CLAP_FEATURES}" STREQUAL "")
+    message(WARNING "No CLAP_FEATURES were specified! Using \"instrument\" by default.")
+    set(CJA_CLAP_FEATURES "instrument")
   endif()
 
   get_property(SRC TARGET clap_juce_sources PROPERTY SOURCES)
@@ -78,10 +83,9 @@ function(clap_juce_extensions_plugin)
   target_include_directories(${claptarget} PRIVATE
           $<TARGET_PROPERTY:${target},INCLUDE_DIRECTORIES>)
 
-  message( STATUS "Setting CLAP_FEATURES to instrument for all plugins" )
   target_compile_definitions(${claptarget} PRIVATE
           CLAP_ID="${CJA_CLAP_ID}"
-          CLAP_FEATURES="instrument" # FIXME
+          CLAP_FEATURES=${CJA_CLAP_FEATURES}
           CLAP_MANUAL_URL="${CJA_CLAP_MANUAL_URL}"
           CLAP_SUPPORT_URL="${CJA_CLAP_SUPPORT_URL}")
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In surge we clap extensions are a sub module side by side with juce.
 ```cmake
     clap_juce_extensions_plugin(TARGET my-target
           CLAP_ID "com.my-cool-plugs.my-target"
-          CLAP_FEATURES "\"equalizer\", \"audio_effect\"")
+          CLAP_FEATURES equalizer audio_effect)
 ```
 
 5. Reload your CMake file and my-target_CLAP will be a buildable target

--- a/README.md
+++ b/README.md
@@ -53,27 +53,52 @@ instructions are as follows:
    source available to your cmake (CPM, side by side check out in CI, etc...).
 2. Load the `clap-juce-extension` in your CMake after you have loaded juce. For instance you could do
 
-```
+```cmake
 add_subdirectory(libs/JUCE) # this is however you load juce
-add_subdirectory(libs/clap-juce-extensions EXCLUDE_FROM_ALL)` 
+add_subdirectory(libs/clap-juce-extensions EXCLUDE_FROM_ALL) 
 ```
 
 In surge we clap extensions are a sub module side by side with juce.
 
 3. Create your juce plugin as normal with formats VST3 etc...
-4. After that `juce_plugin` code, add the following lines (
-   or similar) to your cmake
+4. After that `juce_plugin` code, add the following lines (or similar)
+   to your cmake (a list of pre-defined CLAP
+   features can be found [here](https://github.com/free-audio/clap/blob/main/include/clap/plugin.h#L27)):
 
-```
+```cmake
     clap_juce_extensions_plugin(TARGET my-target
-          CLAP_ID "com.my-cool-plugs.my-target")
+          CLAP_ID "com.my-cool-plugs.my-target"
+          CLAP_FEATURES "\"equalizer\", \"audio_effect\"")
 ```
 
-5Reload your CMake file and my-target_CLAP will be a buildable target
+5. Reload your CMake file and my-target_CLAP will be a buildable target
 
 ## The one missing API from "Forkless"
 
 As mentioned above `wrapperType` will be set to `Undefined` using this method. There's two things you can do about this
 
 1. Live with it. It's probably OK! But if you do need to know your wrapper type
-2. Use the extension mechanism. (ToDo: Document this)
+2. Use the extension mechanism:
+  - `#include "clap-juce-extensions/clap-juce-extensions.h"`
+  - Make your main plugin `juce::AudioProcessor` derive from `clap_juce_extensions::clap_properties`
+  - Use the `is_clap` member variable to figure out the correct wrapper type.
+
+Here's a minimal example:
+```cpp
+#include <JuceHeader.h>
+#include "clap-juce-extensions/clap-juce-extensions.h"
+
+class MyCoolPlugin : public juce::AudioProcessor,
+                     public clap_juce_extensions::clap_properties
+{
+    String getWrapperTypeString()
+    {
+        if (wrapperType == wrapperType_Undefined && is_clap)
+            return "Clap";
+    
+        return juce::AudioProcessor::getWrapperTypeDescription (wrapperType);
+    }
+    
+    ...
+};
+```

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -287,7 +287,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
         }
 
         DBG("audioPortsCount - for " << (isInput ? "Input" : "Output") << " returning "
-                                     << processor->getBusCount(isInput) << " enabled=" << enabledCount);
+                                     << processor->getBusCount(isInput)
+                                     << " enabled=" << enabledCount);
 
         return enabledCount;
     }
@@ -527,7 +528,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
                     else
                     {
                         juce::FloatVectorOperations::copy(busses[ichans], ic,
-                                                          process->frames_count);
+                                                          (int)process->frames_count);
                     }
                 }
                 else


### PR DESCRIPTION
The way the CLAP_FEATURES are being parsed seems a little messy to me at the moment... I feel like there should be a more robust way, if anyone can think of one. It could also be nice to automatically detect if the plugin should be an instrument or audio effect, using JUCE's IS_SYNTH argument, but I feel like that could cause some messy conflicts too.