### PR TITLE
Fix a couple unused parameter warnings

### DIFF
--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -58,7 +58,7 @@ struct clap_extensions
      * in the voice-info clap extension.
      */
     virtual bool supportsVoiceInfo() { return false; }
-    virtual bool voiceInfoGet(clap_voice_info *info) { return false; }
+    virtual bool voiceInfoGet(clap_voice_info * /*info*/) { return false; }
 
     /*
      * Do you want to receive note expression messages? Note that if you return true
@@ -82,7 +82,7 @@ struct clap_extensions
      * directly.
      */
     virtual bool supportsDirectProcess() { return false; }
-    virtual clap_process_status clap_direct_process(const clap_process *process) noexcept
+    virtual clap_process_status clap_direct_process(const clap_process * /*process*/) noexcept
     {
         return CLAP_PROCESS_CONTINUE;
     }

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -387,6 +387,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
     bool notePortsInfo(uint32_t index, bool is_input,
                        clap_note_port_info *info) const noexcept override
     {
+        juce::ignoreUnused (index);
+
         if (is_input)
         {
             info->id = 1 << 5U;


### PR DESCRIPTION
There's also some unused parameters in `<clap/helpers/plugin.hh>`, which gets included from `clap-juce-extensions.h`. If we have JUCE in that header, we could do
```cpp
JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE("-Wunused-parameter")
#include <clap/helpers/plugin.hh>
JUCE_END_IGNORE_WARNINGS_GCC_LIKE
```
but I figured there's probably some reasons why we wouldn't want to have JUCE in that header.