### PR TITLE
Notify on Parameter Changes

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -624,8 +624,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
                     auto nf = pevt->value;
                     jassert(pevt->cookie == paramPtrByClapID[id]);
                     auto jp = static_cast<juce::AudioProcessorParameter *>(pevt->cookie);
-                    // paramSetValueAndNotifyIfChanged(*jp, nf);
-                    jp->setValue(nf);
+                    paramSetValueAndNotifyIfChanged(*jp, nf);
                 }
                 break;
                 case CLAP_EVENT_PARAM_MOD:


### PR DESCRIPTION
As I was writing polyphonic modulation, one of my commits
along the way made the mainline branch not send parameter notifications
which didn't impact surge but broke the FX bank. Restore to
send the notification symmetrically.