### PR TITLE
Support CLAP_NOTE_DIALECT_CLAP in note port

### DIFF
--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -1,7 +1,8 @@
 /*
- * This file contains interface extensions which allow your AudioProcessor or AudioProcessorParameter
- * to implement additional clap-specific API points, and then allows the CLAP wrapper to detect those
- * implementation points and activate advanced features beyond the base JUCE model.
+ * This file contains interface extensions which allow your AudioProcessor or
+ * AudioProcessorParameter to implement additional clap-specific API points, and then allows the
+ * CLAP wrapper to detect those implementation points and activate advanced features beyond the base
+ * JUCE model.
  */
 
 #ifndef SURGE_CLAP_JUCE_EXTENSIONS_H
@@ -86,6 +87,22 @@ struct clap_extensions
     {
         return CLAP_PROCESS_CONTINUE;
     }
+
+    /*
+     * Do I support the CLAP_NOTE_DIALECT_CLAP? And prefer it if so? By default this
+     * is true if I support either note expressions, direct processing, or voice info,
+     * but you can override it for other reasons also, including not liking that default.
+     *
+     * The strictest hosts will not send note expression without this dialect, and so
+     * if you override this to return false, hosts may not give you NE or Voice level
+     * modulators in clap_direct_process.
+     */
+    virtual bool supportsNoteDialectClap(bool /* isInput */)
+    {
+        return supportsNoteExpressions() || supportsVoiceInfo() || supportsDirectProcess();
+    }
+
+    virtual bool prefersNoteDialectClap(bool isInput) { return supportsNoteDialectClap(isInput); }
 };
 
 /*

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -432,7 +432,19 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
                 info->supported_dialects |= CLAP_NOTE_DIALECT_MIDI_MPE;
 
             info->preferred_dialect = CLAP_NOTE_DIALECT_MIDI;
-            strncpy(info->name, "JUCE Midi Input", CLAP_NAME_SIZE);
+
+            if (processorAsClapExtensions)
+            {
+                if (processorAsClapExtensions->supportsNoteDialectClap(true))
+                {
+                    info->supported_dialects |= CLAP_NOTE_DIALECT_CLAP;
+                }
+                if (processorAsClapExtensions->prefersNoteDialectClap(true))
+                {
+                    info->preferred_dialect = CLAP_NOTE_DIALECT_CLAP;
+                }
+            }
+            strncpy(info->name, "JUCE Note Input", CLAP_NAME_SIZE);
         }
         else
         {
@@ -441,7 +453,20 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
             if (processor->supportsMPE())
                 info->supported_dialects |= CLAP_NOTE_DIALECT_MIDI_MPE;
             info->preferred_dialect = CLAP_NOTE_DIALECT_MIDI;
-            strncpy(info->name, "JUCE Midi Output", CLAP_NAME_SIZE);
+
+            if (processorAsClapExtensions)
+            {
+                if (processorAsClapExtensions->supportsNoteDialectClap(false))
+                {
+                    info->supported_dialects |= CLAP_NOTE_DIALECT_CLAP;
+                }
+                if (processorAsClapExtensions->prefersNoteDialectClap(false))
+                {
+                    info->preferred_dialect = CLAP_NOTE_DIALECT_CLAP;
+                }
+            }
+
+            strncpy(info->name, "JUCE Note Output", CLAP_NAME_SIZE);
         }
         return true;
     }


### PR DESCRIPTION
Matters for MultiTrackStudio and other compliant hosts.
Add two new virtual fns to the extension but default impl
is if you support any of voice, note, or direct clap extensions
then you support and prefer CLAP DILECT NOTE CLAP