### PR TITLE
Make sure that ScopedJuceInitialiser is the very last thing to be de-initialized on shutdown

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -112,6 +112,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
                         public juce::ComponentListener
 {
   public:
+    // this needs to be the very last thing to get deleted!
+    juce::ScopedJuceInitialiser_GUI libraryInitializer;
+
     static clap_plugin_descriptor desc;
     std::unique_ptr<juce::AudioProcessor> processor;
     clap_juce_extensions::clap_properties *processorAsClapProperties{nullptr};
@@ -901,7 +904,6 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
   protected:
     juce::CriticalSection stateInformationLock;
     juce::MemoryBlock chunkMemory;
-    juce::ScopedJuceInitialiser_GUI libraryInitializer;
 
   public:
     bool implementsState() const noexcept override { return true; }


### PR DESCRIPTION
I was running into a crash when de-initializing some plugins, since the `ScopedJuceInitialiser` was being deleted before the `juce::AudioProcessor`.

In particular, this was causing problems with `juce::Timer` objects that are left running until their owning class is destroyed, since the timers are managed by the `juce::MessageManager`. When `ScopedJuce` goes away, the message manager does too, so the timers are left dangling.