### PR TITLE
Clang 14 warnings

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1084,14 +1084,14 @@ JUCE_END_IGNORE_WARNINGS_GCC_LIKE
 
 namespace ClapAdapter
 {
-bool clap_init(const char *) { return true; }
+static bool clap_init(const char *) { return true; }
 
-void clap_deinit(void) {}
+static void clap_deinit(void) {}
 
-uint32_t clap_get_plugin_count(const struct clap_plugin_factory *) { return 1; }
+static uint32_t clap_get_plugin_count(const struct clap_plugin_factory *) { return 1; }
 
-const clap_plugin_descriptor *clap_get_plugin_descriptor(const struct clap_plugin_factory *,
-                                                         uint32_t)
+static const clap_plugin_descriptor *clap_get_plugin_descriptor(const struct clap_plugin_factory *,
+                                                                uint32_t)
 {
     return &ClapJuceWrapper::desc;
 }
@@ -1118,13 +1118,13 @@ static const clap_plugin *clap_create_plugin(const struct clap_plugin_factory *,
     return wrapper->clapPlugin();
 }
 
-const struct clap_plugin_factory juce_clap_plugin_factory = {
+static const struct clap_plugin_factory juce_clap_plugin_factory = {
     ClapAdapter::clap_get_plugin_count,
     ClapAdapter::clap_get_plugin_descriptor,
     ClapAdapter::clap_create_plugin,
 };
 
-const void *clap_get_factory(const char *factory_id)
+static const void *clap_get_factory(const char *factory_id)
 {
     if (strcmp(factory_id, CLAP_PLUGIN_FACTORY_ID) == 0)
     {

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -334,9 +334,10 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
 
             if (flags & CLAP_TRANSPORT_HAS_BEATS_TIMELINE)
             {
-                info.ppqPosition = 1.0 * transportInfo->song_pos_beats / CLAP_BEATTIME_FACTOR;
+                info.ppqPosition =
+                    1.0 * (double)transportInfo->song_pos_beats / CLAP_BEATTIME_FACTOR;
                 info.ppqPositionOfLastBarStart =
-                    1.0 * transportInfo->bar_start / CLAP_BEATTIME_FACTOR;
+                    1.0 * (double)transportInfo->bar_start / CLAP_BEATTIME_FACTOR;
             }
             if (flags & CLAP_TRANSPORT_HAS_SECONDS_TIMELINE)
             {
@@ -740,9 +741,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
                 {
                     auto pevt = reinterpret_cast<const clap_event_param_value *>(evt);
 
-                    auto id = pevt->param_id;
                     auto nf = pevt->value;
-                    jassert(pevt->cookie == paramPtrByClapID[id]);
+                    jassert(pevt->cookie == paramPtrByClapID[pevt->param_id]);
                     auto jp = static_cast<juce::AudioProcessorParameter *>(pevt->cookie);
                     paramSetValueAndNotifyIfChanged(*jp, (float)nf);
                 }
@@ -923,7 +923,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
 #if JUCE_MAC
         return guiCocoaAttach(window->cocoa);
 #elif JUCE_LINUX
-        return guiX11Attach(NULL, window->x11);
+        return guiX11Attach(nullptr, window->x11);
 #elif JUCE_WINDOWS
         return guiWin32Attach(window->win32);
 #else


### PR DESCRIPTION
See #55 

## Solution for missing prototypes

Some functions where already marked as static (e.g. clap_create_plugin). I've added it where it was missing. This will not change behavior as it only affects the name mangling. CppCoreGuidelines recommend an [unnamed namespace instead](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-unnamed2), but the result is exactly the same.

The reasoning behind the warning seems to be, to protect against typos between header & source files. See [here](https://reviews.llvm.org/D59402)

Running `clap-info` on a plugin with these changes applied gives the same result as before. (as expected)