### PR TITLE
A few linux behavior changes

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -174,6 +174,15 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
     {
         defineAudioPorts();
 
+        /*
+         * At 1.0 the spec was silent on whether a plugin could call host extension methods
+         * on ::init. Some hosts failed timerSupportRegister at init since they hadn't had
+         * the chance to see if a plugin supports the timer extension. A conversation ensued
+         * and is still ongoing, but to avoid ambiguity, we take the timer initialization we
+         * used to do for linux here and move it to an onMainThread call the host will make
+         * once initialization is complete, by using requestCallback, which hosts must implement
+         * at init time.
+         */
         haveCompletedDeferredInit = false;
         _host.requestCallback();
         return true;
@@ -188,7 +197,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<clap::helpers::Misbehaviour
 #if JUCE_LINUX
             if (_host.canUseTimerSupport())
             {
-                _host.timerSupportRegister(1000 / 50, &idleTimer);
+                // A 60hz timer seens reasonable for these UI and message queue things
+                _host.timerSupportRegister(1000 / 60, &idleTimer);
             }
 #endif
         }


### PR DESCRIPTION
A few changes which only impact the Linux implementation

1. Call the timer register in a deferred callback launched from
   init
2. implementsGui has a `canUseTimerSupport` check

Closes #63