### PR TITLE
Rename some extension decoration classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,11 @@ a workaround for using our extensions mechanism, below.
    in our adapter (although they are supported in the CLAP API of course). We would love a test plugin to help us
    resolve this.
 
-## The Extensions API
+## The `clap_juce_extensions` API for extended CLAP capabilities in JUCE
 
 There are a set of things which JUCE doesn't support which CLAP does. Rather than not support them in our
-plugins, we've decided to create an extensions API. These are a set of classes which your AudioProcessor can
+plugins, we've decided to create an specific extensions API which allow you to decorate JUCE
+classes with extended capabilities. These are a set of classes which your AudioProcessor can
 implement and, if it does, then the CLAP JUCE wrapper will call the associated functions.
 
 The extension are in "include/clap-juce-extensions.h" and are documented there, but currently have
@@ -182,10 +183,10 @@ three classes
     - if you subclass this your AudioProcessor will have a collection of members which give you extra CLAP info
     - Most usefully, you get an `is_clap` member which is false if not a CLAP and true if it is, which works around
       the fact that our 'forkless' approach doesn't let us add a `AudioProcessor::WrapperType` to the JUCE API
-- `clap_juce_extensions::clap_extensions`
+- `clap_juce_extensions::clap_juce_audio_processor_capabilities`
     - these are a set of advanced extensions which let you optionally interact more directly with the CLAP API
       and are mostly useful for advanced features like non-destructive modulation and note expression support
-- `clap_juce_extensions::clap_param_extensions`
+- `clap_juce_extensions::clap_juce_parameter_capabilities`
     - If your AudioProcessorParameter subclass implements this API, you can share extended CLAP information on
       a parameter by parameter basis
 

--- a/examples/GainPlugin/GainPlugin.h
+++ b/examples/GainPlugin/GainPlugin.h
@@ -5,7 +5,7 @@
 
 class ModulatableFloatParameter;
 class GainPlugin : public juce::AudioProcessor,
-                   public clap_juce_extensions::clap_extensions,
+                   public clap_juce_extensions::clap_juce_audio_processor_capabilities,
                    protected clap_juce_extensions::clap_properties
 {
   public:

--- a/examples/GainPlugin/ModulatableFloatParameter.h
+++ b/examples/GainPlugin/ModulatableFloatParameter.h
@@ -7,7 +7,7 @@ JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE("-Wunused-parameter", "-Wextra-semi", "-Wnon
 JUCE_END_IGNORE_WARNINGS_GCC_LIKE
 
 class ModulatableFloatParameter : public juce::AudioParameterFloat,
-                                  public clap_juce_extensions::clap_param_extensions
+                                  public clap_juce_extensions::clap_juce_parameter_capabilities
 {
   public:
     ModulatableFloatParameter(const juce::String &parameterID, const juce::String &parameterName,

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -1,5 +1,5 @@
 /*
- * This file contains C++ interface classeswhich allow your AudioProcessor or
+ * This file contains C++ interface classes which allow your AudioProcessor or
  * AudioProcessorParameter to implement additional clap-specific capabilities, and then allows the
  * CLAP wrapper to detect those capabilities and activate advanced features beyond the base
  * JUCE model.

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -1,7 +1,7 @@
 /*
- * This file contains interface extensions which allow your AudioProcessor or
- * AudioProcessorParameter to implement additional clap-specific API points, and then allows the
- * CLAP wrapper to detect those implementation points and activate advanced features beyond the base
+ * This file contains C++ interface classeswhich allow your AudioProcessor or
+ * AudioProcessorParameter to implement additional clap-specific capabilities, and then allows the
+ * CLAP wrapper to detect those capabilities and activate advanced features beyond the base
  * JUCE model.
  */
 
@@ -36,11 +36,12 @@ struct clap_properties
 };
 
 /*
- * clap_extensions allows you to interact with advanced properties of the CLAP api.
- * The default implementations here mean if you implement clap_extensions and override
- * nothing, you get the same behaviour as if you hadn't implemented it.
+ * clap_juce_audio_processor_capabilities allows you to interact with advanced properties of the
+ * CLAP api. The default implementations here mean if you implement
+ * clap_juce_audio_processor_capabilities and override nothing, you get the same behaviour as if you
+ * hadn't implemented it.
  */
-struct clap_extensions
+struct clap_juce_audio_processor_capabilities
 {
     /*
      * In some cases, there is no main input, and input 0 is not main. Allow your plugin
@@ -106,11 +107,11 @@ struct clap_extensions
 };
 
 /*
- * clap_param_extensions is intended to be applied to AudioParameter subclasses. When
+ * clap_juce_parameter_capabilities is intended to be applied to AudioParameter subclasses. When
  * asking your JUCE plugin for parameters, the clap wrapper will check if your parameter
- * implements the extensions and call the associated functions.
+ * implements the capabilities and call the associated functions.
  */
-struct clap_param_extensions
+struct clap_juce_parameter_capabilities
 {
     /*
      * Return true if this parameter should receive non-destructive

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -109,7 +109,6 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC(4996) // allow strncpy
 #define CLAP_MISBEHAVIOUR_HANDLER_LEVEL "Ignore"
 #endif
 
-
 #if !defined(CLAP_CHECKING_LEVEL)
 #define CLAP_CHECKING_LEVEL "Minimal"
 #endif
@@ -119,7 +118,6 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC(4996) // allow strncpy
 // #define CLAP_MISBEHAVIOUR_HANDLER_LEVEL Terminate
 // #undef CLAP_CHECKING_LEVEL
 // #define CLAP_CHECKING_LEVEL Maximal
-
 
 /*
  * A little class that sets an atomic bool to a value across its lifetime and
@@ -152,7 +150,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     static clap_plugin_descriptor desc;
     std::unique_ptr<juce::AudioProcessor> processor;
     clap_juce_extensions::clap_properties *processorAsClapProperties{nullptr};
-    clap_juce_extensions::clap_extensions *processorAsClapExtensions{nullptr};
+    clap_juce_extensions::clap_juce_audio_processor_capabilities *processorAsClapExtensions{
+        nullptr};
 
     bool usingLegacyParameterAPI{false};
 
@@ -166,7 +165,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         processor->addListener(this);
 
         processorAsClapProperties = dynamic_cast<clap_juce_extensions::clap_properties *>(p);
-        processorAsClapExtensions = dynamic_cast<clap_juce_extensions::clap_extensions *>(p);
+        processorAsClapExtensions =
+            dynamic_cast<clap_juce_extensions::clap_juce_audio_processor_capabilities *>(p);
 
         const bool forceLegacyParamIDs = false;
 
@@ -688,14 +688,14 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             info->flags = info->flags | CLAP_PARAM_IS_STEPPED;
         }
 
-        auto cpe = dynamic_cast<clap_juce_extensions::clap_param_extensions *>(pbi);
-        if (cpe)
+        auto cpc = dynamic_cast<clap_juce_extensions::clap_juce_parameter_capabilities *>(pbi);
+        if (cpc)
         {
-            if (cpe->supportsMonophonicModulation())
+            if (cpc->supportsMonophonicModulation())
             {
                 info->flags = info->flags | CLAP_PARAM_IS_MODULATABLE;
             }
-            if (cpe->supportsPolyphonicModulation())
+            if (cpc->supportsPolyphonicModulation())
             {
                 info->flags =
                     info->flags | CLAP_PARAM_IS_MODULATABLE |


### PR DESCRIPTION
Based on user feedback the name `clap_juce_extensions::clap_extensions`
was terribly confusing. Sounded like a way to extend juce to access
clap extensions. So we renamed it to `clap_juce_extensions::clap_juce_audio_processor_capabilities`
since it is extensions to juce for clap which augments your audio processor
with capabilities (and make a similar change to params).

This is a breaking change if you use extensions but is fixed with
a simple rename.