### PR TITLE
Add option for setting a custom binary name with Projucer builds

### DIFF
--- a/cmake/ClapTargetHelpers.cmake
+++ b/cmake/ClapTargetHelpers.cmake
@@ -130,40 +130,24 @@ endfunction()
 
 function(clap_juce_extensions_plugin)
     set(oneValueArgs TARGET)
-    set(multiValueArgs CLAP_ID CLAP_FEATURES CLAP_MANUAL_URL CLAP_SUPPORT_URL)
     cmake_parse_arguments(CJA "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(product_name $<TARGET_PROPERTY:${CJA_TARGET},JUCE_PRODUCT_NAME>)
     get_target_property(docopy "${CJA_TARGET}" JUCE_COPY_PLUGIN_AFTER_BUILD)
 
     clap_juce_extensions_plugin_internal(
-        TARGET ${CJA_TARGET}
         PLUGIN_NAME "${product_name}"
         IS_JUCER FALSE
         DO_COPY ${docopy}
-        CLAP_ID "${CJA_CLAP_ID}"
-        CLAP_FEATURES "${CJA_CLAP_FEATURES}"
-        CLAP_MANUAL_URL "${CJA_CLAP_MANUAL_URL}"
-        CLAP_SUPPORT_URL "${CJA_CLAP_SUPPORT_URL}"
+        ${ARGV}
     )
 endfunction()
 
 # modified version of clap_juce_extensions_plugin
 # for use with Projucer projects
 function(clap_juce_extensions_plugin_jucer)
-    set(oneValueArgs TARGET TARGET_PATH PLUGIN_NAME DO_COPY)
-    set(multiValueArgs CLAP_ID CLAP_FEATURES CLAP_MANUAL_URL CLAP_SUPPORT_URL)
-    cmake_parse_arguments(CJA "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
     clap_juce_extensions_plugin_internal(
-        TARGET ${CJA_TARGET}
-        TARGET_PATH "${CJA_TARGET_PATH}"
-        PLUGIN_NAME "${CJA_PLUGIN_NAME}"
         IS_JUCER TRUE
-        DO_COPY ${CJA_DO_COPY}
-        CLAP_ID "${CJA_CLAP_ID}"
-        CLAP_FEATURES "${CJA_CLAP_FEATURES}"
-        CLAP_MANUAL_URL "${CJA_CLAP_MANUAL_URL}"
-        CLAP_SUPPORT_URL "${CJA_CLAP_SUPPORT_URL}"
+        ${ARGV}
     )
 endfunction()

--- a/cmake/JucerClap.cmake
+++ b/cmake/JucerClap.cmake
@@ -1,9 +1,13 @@
 # use this function to create a CLAP from a jucer project
 function(create_jucer_clap_target)
-    set(oneValueArgs TARGET PLUGIN_NAME MANUFACTURER_NAME MANUFACTURER_URL VERSION_STRING MANUFACTURER_CODE PLUGIN_CODE EDITOR_NEEDS_KEYBOARD_FOCUS MISBEHAVIOUR_HANDLER_LEVEL CHECKING_LEVEL)
+    set(oneValueArgs TARGET PLUGIN_NAME BINARY_NAME MANUFACTURER_NAME MANUFACTURER_URL VERSION_STRING MANUFACTURER_CODE PLUGIN_CODE EDITOR_NEEDS_KEYBOARD_FOCUS MISBEHAVIOUR_HANDLER_LEVEL CHECKING_LEVEL)
     set(multiValueArgs CLAP_ID CLAP_FEATURES CLAP_MANUAL_URL CLAP_SUPPORT_URL)
 
     cmake_parse_arguments(CJA "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if ("${CJA_BINARY_NAME}" STREQUAL "")
+        set(CJA_BINARY_NAME "${CJA_TARGET}")
+    endif()
 
     if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
         message(WARNING "CMAKE_BUILD_TYPE not set... using Release by default")
@@ -39,7 +43,7 @@ function(create_jucer_clap_target)
     clap_juce_extensions_plugin_jucer(
         TARGET ${CJA_TARGET}
         TARGET_PATH "${PLUGIN_LIBRARY_PATH}"
-        PLUGIN_NAME "${CJA_PLUGIN_NAME}"
+        PLUGIN_NAME "${CJA_BINARY_NAME}"
         CLAP_ID "${CJA_CLAP_ID}"
         CLAP_FEATURES "${CJA_CLAP_FEATURES}"
         CLAP_MANUAL_URL "${CJA_CLAP_MANUAL_URL}"


### PR DESCRIPTION
If no binary name is set, the default name will be the same as the target name (this replicates the default behaviour of the Projucer).