### PR TITLE
Param notifications

### DIFF
--- a/examples/GainPlugin/GainPlugin.cpp
+++ b/examples/GainPlugin/GainPlugin.cpp
@@ -166,12 +166,7 @@ void GainPlugin::process_clap_event(const clap_event_header_t *event)
     case CLAP_EVENT_PARAM_VALUE:
     {
         auto paramEvent = reinterpret_cast<const clap_event_param_value *>(event);
-        auto juceParameter = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
-
-        if (juceParameter->getValue() == (float)paramEvent->value)
-            return;
-
-        juceParameter->setValueNotifyingHost((float)paramEvent->value);
+        handleParameterChange(paramEvent);
     }
     break;
     case CLAP_EVENT_PARAM_MOD:

--- a/examples/GainPlugin/GainPlugin.h
+++ b/examples/GainPlugin/GainPlugin.h
@@ -43,9 +43,10 @@ class GainPlugin : public juce::AudioProcessor,
 
     juce::String getPluginTypeString() const;
     auto *getGainParameter() { return gainDBParameter; }
+    auto &getValueTreeState() { return vts; }
 
   private:
-    static void process_clap_event(const clap_event_header_t *event);
+    void process_clap_event(const clap_event_header_t *event);
 
     ModulatableFloatParameter *gainDBParameter = nullptr;
 

--- a/examples/GainPlugin/PluginEditor.h
+++ b/examples/GainPlugin/PluginEditor.h
@@ -2,15 +2,19 @@
 
 #include "GainPlugin.h"
 
-class PluginEditor : public juce::AudioProcessorEditor
+class PluginEditor : public juce::AudioProcessorEditor,
+                     private juce::AudioProcessorValueTreeState::Listener
 {
   public:
     explicit PluginEditor(GainPlugin &plugin);
+    ~PluginEditor() override;
 
     void resized() override;
     void paint(juce::Graphics &g) override;
 
   private:
+    void parameterChanged(const juce::String &parameterID, float newValue) override;
+
     GainPlugin &plugin;
 
     juce::Slider gainSlider;

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -12,6 +12,9 @@
 #include <clap/plugin.h>
 #include <clap/helpers/plugin.hh>
 
+/** Forward declaration of the wrapper class. */
+class ClapJuceWrapper;
+
 namespace clap_juce_extensions
 {
 /*
@@ -89,6 +92,16 @@ struct clap_juce_audio_processor_capabilities
         return CLAP_PROCESS_CONTINUE;
     }
 
+    /**
+     * If you're implementing `clap_direct_process`, you should use this method
+     * to handle `CLAP_EVENT_PARAM_VALUE`, so that the parameter listeners are
+     * called on the main thread without creating a feedback loop.
+     */
+    void handleParameterChange(const clap_event_param_value *paramEvent)
+    {
+        parameterChangeHandler(paramEvent);
+    }
+
     /*
      * Do I support the CLAP_NOTE_DIALECT_CLAP? And prefer it if so? By default this
      * is true if I support either note expressions, direct processing, or voice info,
@@ -104,6 +117,10 @@ struct clap_juce_audio_processor_capabilities
     }
 
     virtual bool prefersNoteDialectClap(bool isInput) { return supportsNoteDialectClap(isInput); }
+
+  private:
+    friend class ::ClapJuceWrapper;
+    std::function<void(const clap_event_param_value *)> parameterChangeHandler = nullptr;
 };
 
 /*

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -172,11 +172,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         {
             processorAsClapExtensions->parameterChangeHandler =
                 [this](const clap_event_param_value *paramEvent) {
-                    auto nf = paramEvent->value;
-                    jassert(paramEvent->cookie == paramPtrByClapID[paramEvent->param_id]);
-                    auto jp = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
-
-                    paramSetValueAndNotifyIfChanged(*jp, (float)nf);
+                    handleParameterChangeEvent(paramEvent);
                 };
         };
 
@@ -766,6 +762,15 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         return true;
     }
 
+    void handleParameterChangeEvent(const clap_event_param_value *paramEvent)
+    {
+        auto nf = paramEvent->value;
+        jassert(paramEvent->cookie == paramPtrByClapID[paramEvent->param_id]);
+        auto jp = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
+
+        paramSetValueAndNotifyIfChanged(*jp, (float)nf);
+    }
+
     void paramSetValueAndNotifyIfChanged(juce::AudioProcessorParameter &param, float newValue)
     {
         if (param.getValue() == newValue)
@@ -1069,12 +1074,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         case CLAP_EVENT_PARAM_VALUE:
         {
             auto paramEvent = reinterpret_cast<const clap_event_param_value *>(event);
-
-            auto nf = paramEvent->value;
-            jassert(paramEvent->cookie == paramPtrByClapID[paramEvent->param_id]);
-            auto jp = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
-
-            paramSetValueAndNotifyIfChanged(*jp, (float)nf);
+            handleParameterChangeEvent(paramEvent);
         }
         break;
         case CLAP_EVENT_PARAM_MOD:

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -132,18 +132,6 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC(4996) // allow strncpy
 // #define CLAP_CHECKING_LEVEL Maximal
 
 /*
- * A little class that sets an atomic bool to a value across its lifetime and
- * restores it on exit.
- */
-template <typename T> struct AtomicTGuard
-{
-    std::atomic<T> &ref;
-    T valAtConstruct;
-    AtomicTGuard(std::atomic<T> &b, T val) : ref(b), valAtConstruct(b) { ref = val; }
-    ~AtomicTGuard() { ref = valAtConstruct; }
-};
-
-/*
  * The ClapJuceWrapper is a class which immplements a collection
  * of CLAP and JUCE APIs
  */
@@ -179,6 +167,18 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         processorAsClapProperties = dynamic_cast<clap_juce_extensions::clap_properties *>(p);
         processorAsClapExtensions =
             dynamic_cast<clap_juce_extensions::clap_juce_audio_processor_capabilities *>(p);
+
+        if (processorAsClapExtensions != nullptr)
+        {
+            processorAsClapExtensions->parameterChangeHandler =
+                [this](const clap_event_param_value *paramEvent) {
+                    auto nf = paramEvent->value;
+                    jassert(paramEvent->cookie == paramPtrByClapID[paramEvent->param_id]);
+                    auto jp = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
+
+                    paramSetValueAndNotifyIfChanged(*jp, (float)nf);
+                };
+        };
 
         const bool forceLegacyParamIDs = false;
 
@@ -345,29 +345,26 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         return id;
     }
 
-    std::atomic<bool> supressParameterChangeMessages{false};
+    bool supressParameterChangeMessages{false};
     void audioProcessorParameterChanged(juce::AudioProcessor *, int index, float newValue) override
     {
         if (cacheHostCanUseThreadCheck)
         {
-            /*
-             * In this event the host can tell us the audio thread and so we can supress this
-             * outbound message which would have resulted from the parameter change in the ::process
-             * loop
-             */
+            // Parameter change messages should not be coming from the audio thread!
+            // If you're implementing `clap_direct_process`, make sure to use
+            // `clap_juce_audio_processor_capabilities::handleParameterChange()`
             if (_host.isAudioThread())
+            {
+                jassertfalse;
                 return;
+            }
         }
-        else
-        {
-            /*
-             * In this case the host can't give us thread identities. To make sure we don't double
-             * send an event, use an atomic bool to send the result. This may in a very rare
-             * condition drop a UI event but will avoid a feedback cycle from the UI
-             */
-            if (supressParameterChangeMessages)
-                return;
-        }
+
+        // This change message came from an event that we've already handled.
+        // Let's return here to avoid creating a feedback loop!
+        if (supressParameterChangeMessages)
+            return;
+
         auto id = clapIdFromParameterIndex(index);
         uiParamChangeQ.push({CLAP_EVENT_PARAM_VALUE, 0, id, newValue});
     }
@@ -769,13 +766,28 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         return true;
     }
 
-    static void paramSetValueAndNotifyIfChanged(juce::AudioProcessorParameter &param,
-                                                float newValue)
+    void paramSetValueAndNotifyIfChanged(juce::AudioProcessorParameter &param, float newValue)
     {
         if (param.getValue() == newValue)
             return;
 
-        param.setValueNotifyingHost(newValue);
+        param.setValue(newValue);
+
+        // we want to trigger the parameter listener callbacks on the main thread,
+        // but MessageManager::callAsync is not safe to call from the audio thread.
+        audioThreadParamListenerQ.push(ParamListenerCall{&param, newValue});
+        _host.requestCallback();
+    }
+
+    void onMainThread() noexcept override
+    {
+        // handle parameter change listener callbacks
+        juce::ScopedValueSetter<bool> suppressCallbacks{supressParameterChangeMessages, true};
+        ParamListenerCall listenerCall{};
+        while (audioThreadParamListenerQ.pop(listenerCall))
+        {
+            listenerCall.parameter->sendValueChangedMessageToListeners(listenerCall.newValue);
+        }
     }
 
     bool implementsLatency() const noexcept override { return true; }
@@ -1062,13 +1074,6 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             jassert(paramEvent->cookie == paramPtrByClapID[paramEvent->param_id]);
             auto jp = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
 
-            /*
-             * In the event that a param value comes in from the host, we don't want
-             * to send it back out as a UI message but we do want to trigger any *other*
-             * listeners which may be attached. So suppress my listeners while we send this
-             * event.
-             */
-            auto g = AtomicTGuard<bool>(supressParameterChangeMessages, true);
             paramSetValueAndNotifyIfChanged(*jp, (float)nf);
         }
         break;
@@ -1338,6 +1343,13 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         float newval{0};
     };
     PushPopQ<ParamChange, 4096 * 16> uiParamChangeQ;
+
+    struct ParamListenerCall
+    {
+        juce::AudioProcessorParameter *parameter = nullptr;
+        float newValue = 0.0f;
+    };
+    PushPopQ<ParamListenerCall, 4096 * 16> audioThreadParamListenerQ;
 
     /*
      * Various maps for ID lookups


### PR DESCRIPTION
When handling parameter changes on the audio thread, call `param->setValue()` immediately, and add the parameter change to a queue. Then on the main thread, call `param->sendValueChangedMessageToListeners()` for all the queued parameter changes. I also looked at using `juce::Timer::callAfterDelay()` or `juce::MessageManager::callAsync()` for calling the listeners, but it seems like these methods are not safe to call on the audio thread.

This PR also adds a method to `clap_juce_audio_processor_capabilities` so plugins implementing `clap_direct_process` can handle parameter changes the same way the wrapper does.

So far I've tested this change with the example plugin and ChowTape.

Also, the example plugin now has a little red light which blinks when parameter change listener callbacks are happening. This was useful for debugging, so I figured I'd leave it in.