### PR TITLE
Treat warnings as errors for CI builds

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Configure
         shell: bash
-        run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCLAP_JUCE_VERSION=$JUCE_VERSION
+        run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCLAP_JUCE_VERSION=$JUCE_VERSION -DCLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS=ON
         env:
           JUCE_VERSION: ${{ matrix.juce_version }}
 

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: cmake --build build --config Release --parallel 4
+        run: cmake --build build --config Release --parallel 4 --target GainPlugin_CLAP
 
       - name: Set up clap-info
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@
 # require at least CMAKE 3.21
 cmake_minimum_required (VERSION 3.21 FATAL_ERROR)
 
+get_directory_property(parent_dir PARENT_DIRECTORY)
+if ("${parent_dir}" STREQUAL "")
+    # OSX deployment target needs to be set before the `project()` call
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7" CACHE STRING "Minimum OS X deployment target")
+    set(is_toplevel 1)
+else ()
+    set(is_toplevel 0)
+endif ()
+
 project(clap-juce-extensions VERSION 0.1.0 LANGUAGES C CXX)
 
 if (CMAKE_CXX_STANDARD)
@@ -26,12 +35,6 @@ endif()
 message( STATUS "Building CLAP with CLAP_CXX_STANDARD=${CLAP_CXX_STANDARD}")
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-get_directory_property(parent_dir PARENT_DIRECTORY)
-if ("${parent_dir}" STREQUAL "")
-    set(is_toplevel 1)
-else ()
-    set(is_toplevel 0)
-endif ()
 option(CLAP_JUCE_EXTENSIONS_BUILD_EXAMPLES "Add targets for building and running clap-juce-extensions examples" ${is_toplevel})
 if(CLAP_JUCE_EXTENSIONS_BUILD_EXAMPLES)
     # The examples need JUCE to be imported before the CLAP helper targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_minimum_required (VERSION 3.21 FATAL_ERROR)
 get_directory_property(parent_dir PARENT_DIRECTORY)
 if ("${parent_dir}" STREQUAL "")
     # OSX deployment target needs to be set before the `project()` call
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7" CACHE STRING "Minimum OS X deployment target")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment target")
     set(is_toplevel 1)
 else ()
     set(is_toplevel 0)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,4 +4,12 @@ set(JUCE_FORMATS AU VST3 Standalone)
 
 option(CLAP_WRAP_PROJUCER_PLUGIN "Wrap a CLAP plugin from a Projucer build" OFF)
 
+option(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors for the example plugin builds" OFF)
+if(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS)
+    add_compile_options(
+      $<$<CXX_COMPILER_ID:MSVC>:/WX>
+      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
+    )
+endif()
+
 add_subdirectory(GainPlugin)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,11 +6,18 @@ option(CLAP_WRAP_PROJUCER_PLUGIN "Wrap a CLAP plugin from a Projucer build" OFF)
 
 option(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors for the example plugin builds" OFF)
 if(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS)
-    message(STATUS "Building CLAP example plugins with \"-Werror\"")
-    add_compile_options(
-        $<$<CXX_COMPILER_ID:MSVC>:/WX>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
+    message(STATUS "Building CLAP extension sources with \"-Werror\"")
+    target_compile_options(clap_juce_extensions
+        PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/WX>
+            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
     )
+
+   target_compile_options(clap_juce_sources
+       PRIVATE
+           $<$<CXX_COMPILER_ID:MSVC>:/WX>
+           $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
+   )
 endif()
 
 add_subdirectory(GainPlugin)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,9 +6,10 @@ option(CLAP_WRAP_PROJUCER_PLUGIN "Wrap a CLAP plugin from a Projucer build" OFF)
 
 option(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors for the example plugin builds" OFF)
 if(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS)
+    message(STATUS "Building CLAP example plugins with \"-Werror\"")
     add_compile_options(
-      $<$<CXX_COMPILER_ID:MSVC>:/WX>
-      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
     )
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,18 +6,18 @@ option(CLAP_WRAP_PROJUCER_PLUGIN "Wrap a CLAP plugin from a Projucer build" OFF)
 
 option(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors for the example plugin builds" OFF)
 if(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS)
-    message(STATUS "Building CLAP extension sources with \"-Werror\"")
-    target_compile_options(clap_juce_extensions
-        PRIVATE
-            $<$<CXX_COMPILER_ID:MSVC>:/WX>
-            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
+    message(STATUS "Building CLAP example plugins with \"-Werror\"")
+    add_compile_options(
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
     )
 
-   target_compile_options(clap_juce_sources
-       PRIVATE
-           $<$<CXX_COMPILER_ID:MSVC>:/WX>
-           $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
-   )
+    # JUCE 6.0.7 gets a deprecated declaration in its CoreAudio
+    # code. We can remove this once we're no longer building JUCE
+    # 6.0.7 in our CI.
+    if(APPLE AND CLAP_JUCE_VERSION STREQUAL "6.0.7")
+        add_compile_options(-Wno-deprecated-declarations)
+    endif()
 endif()
 
 add_subdirectory(GainPlugin)

--- a/examples/GainPlugin/ModulatableFloatParameter.h
+++ b/examples/GainPlugin/ModulatableFloatParameter.h
@@ -15,6 +15,7 @@ class ModulatableFloatParameter : public juce::AudioParameterFloat,
                               float defaultFloatValue,
                               const std::function<juce::String(float)> &valueToTextFunction,
                               std::function<float(const juce::String &)> &&textToValueFunction)
+#if JUCE_VERSION < 0x070000
         : juce::AudioParameterFloat(
               parameterID, parameterName, valueRange, defaultFloatValue, juce::String(),
               AudioProcessorParameter::genericParameter,
@@ -22,6 +23,14 @@ class ModulatableFloatParameter : public juce::AudioParameterFloat,
                   ? std::function<juce::String(float v, int)>()
                   : [valueToTextFunction](float v, int) { return valueToTextFunction(v); },
               std::move(textToValueFunction)),
+#else
+        : juce::AudioParameterFloat(
+              parameterID, parameterName, valueRange, defaultFloatValue,
+              juce::AudioParameterFloatAttributes()
+                  .withStringFromValueFunction(
+                      [valueToTextFunction](float v, int) { return valueToTextFunction(v); })
+                  .withValueFromStringFunction(std::move(textToValueFunction))),
+#endif
           unsnappedDefault(valueRange.convertTo0to1(defaultFloatValue)),
           normalisableRange(valueRange)
     {

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -320,7 +320,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
          * Before 6.0.8 it was unclear what changed. For now make the approximating decision to just
          * rescan values and text.
          */
-        juce::ignoreUnused(proc);
+        //        juce::ignoreUnused(proc);
         runOnMainThread([this] {
             if (isBeingDestroyed())
                 return;

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -320,7 +320,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
          * Before 6.0.8 it was unclear what changed. For now make the approximating decision to just
          * rescan values and text.
          */
-        //        juce::ignoreUnused(proc);
+        juce::ignoreUnused(proc);
         runOnMainThread([this] {
             if (isBeingDestroyed())
                 return;

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -320,6 +320,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
          * Before 6.0.8 it was unclear what changed. For now make the approximating decision to just
          * rescan values and text.
          */
+        juce::ignoreUnused(proc);
         runOnMainThread([this] {
             if (isBeingDestroyed())
                 return;


### PR DESCRIPTION
Between the different JUCE versions and compilers, it's unfortunately easy to accidentally introduce a compiler error. Hopefully this should catch us.