### PR TITLE
Expose JUCE parameter ranges to CLAP hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ are available
   required to process a chunk smaller than the chosen resolution.
 * `CLAP_USE_JUCE_PARAMETER_RANGES` can be set to `1` (on) or `0` (off, default) to
   tell the wrapper to use JUCE's parameter ranges when possible, rather than
-  "normalized" 0-1 parameter ranges for communicatign parameter information with
+  "normalized" 0-1 parameter ranges for communicating parameter information with
   with the host.
 
 ## Risks of using this library

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ are available
   sent from the host. Note that if the block size provided by the host is not an
   even multiple of `CLAP_PROCESS_EVENTS_RESOLUTION_SAMPLES`, the plugin may be
   required to process a chunk smaller than the chosen resolution.
+* `CLAP_USE_JUCE_PARAMETER_RANGES` can be set to `1` (on) or `0` (off, default) to
+  tell the wrapper to use JUCE's parameter ranges when possible, rather than
+  "normalized" 0-1 parameter ranges for communicatign parameter information with
+  with the host.
 
 ## Risks of using this library
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ are available
   sent from the host. Note that if the block size provided by the host is not an
   even multiple of `CLAP_PROCESS_EVENTS_RESOLUTION_SAMPLES`, the plugin may be
   required to process a chunk smaller than the chosen resolution.
-* `CLAP_USE_JUCE_PARAMETER_RANGES` can be set to `1` (on) or `0` (off, default) to
-  tell the wrapper to use JUCE's parameter ranges when possible, rather than
-  "normalized" 0-1 parameter ranges for communicating parameter information with
-  with the host.
+* `CLAP_USE_JUCE_PARAMETER_RANGES` can be set to `ALL`, `DISCRETE` or `OFF` (default) to
+  tell the wrapper to use JUCE's parameter ranges for all parameters, discrete parameters only,
+  or no parameters. When not using JUCE's parameter ranges, the plugin will communicate with
+  the host using 0-1 parameter ranges for the given parameter,
 
 ## Risks of using this library
 

--- a/cmake/ClapTargetHelpers.cmake
+++ b/cmake/ClapTargetHelpers.cmake
@@ -49,7 +49,7 @@ function(clap_juce_extensions_plugin_internal)
 
     if ("${CJA_CLAP_USE_JUCE_PARAMETER_RANGES}" STREQUAL "")
         message( STATUS "Setting \"Use JUCE parameter ranges\" to OFF")
-        set(CJA_CLAP_USE_JUCE_PARAMETER_RANGES 0)
+        set(CJA_CLAP_USE_JUCE_PARAMETER_RANGES OFF)
     else()
         message( STATUS "Setting \"Use JUCE parameter ranges\" to ${CJA_CLAP_USE_JUCE_PARAMETER_RANGES}")
     endif()
@@ -121,7 +121,7 @@ function(clap_juce_extensions_plugin_internal)
             CLAP_CHECKING_LEVEL=${CJA_CLAP_CHECKING_LEVEL}
             CLAP_PROCESS_EVENTS_RESOLUTION_SAMPLES=${CJA_CLAP_PROCESS_EVENTS_RESOLUTION_SAMPLES}
             CLAP_ALWAYS_SPLIT_BLOCK=${CJA_CLAP_ALWAYS_SPLIT_BLOCK}
-            CLAP_USE_JUCE_PARAMETER_RANGES=${CJA_CLAP_USE_JUCE_PARAMETER_RANGES}
+            CLAP_USE_JUCE_PARAMETER_RANGES=CLAP_USE_JUCE_PARAMETER_RANGES_${CJA_CLAP_USE_JUCE_PARAMETER_RANGES}
             )
 
     if(${CJA_IS_JUCER})

--- a/cmake/ClapTargetHelpers.cmake
+++ b/cmake/ClapTargetHelpers.cmake
@@ -1,7 +1,7 @@
 function(clap_juce_extensions_plugin_internal)
     set(oneValueArgs TARGET TARGET_PATH PLUGIN_BINARY_NAME IS_JUCER PLUGIN_VERSION DO_COPY CLAP_MANUAL_URL
             CLAP_SUPPORT_URL CLAP_MISBEHAVIOUR_HANDLER_LEVEL CLAP_CHECKING_LEVEL CLAP_PROCESS_EVENTS_RESOLUTION_SAMPLES
-            CLAP_ALWAYS_SPLIT_BLOCK)
+            CLAP_ALWAYS_SPLIT_BLOCK CLAP_USE_JUCE_PARAMETER_RANGES)
     set(multiValueArgs CLAP_ID CLAP_FEATURES)
   
     cmake_parse_arguments(CJA "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -45,6 +45,13 @@ function(clap_juce_extensions_plugin_internal)
         set(CJA_CLAP_ALWAYS_SPLIT_BLOCK 0)
     else()
         message( STATUS "Setting \"Always split block\" to ${CJA_CLAP_ALWAYS_SPLIT_BLOCK}")
+    endif()
+
+    if ("${CJA_CLAP_USE_JUCE_PARAMETER_RANGES}" STREQUAL "")
+        message( STATUS "Setting \"Use JUCE parameter ranges\" to OFF")
+        set(CJA_CLAP_USE_JUCE_PARAMETER_RANGES 0)
+    else()
+        message( STATUS "Setting \"Use JUCE parameter ranges\" to ${CJA_CLAP_USE_JUCE_PARAMETER_RANGES}")
     endif()
 
     # we need the list of features as comma separated quoted strings
@@ -114,6 +121,7 @@ function(clap_juce_extensions_plugin_internal)
             CLAP_CHECKING_LEVEL=${CJA_CLAP_CHECKING_LEVEL}
             CLAP_PROCESS_EVENTS_RESOLUTION_SAMPLES=${CJA_CLAP_PROCESS_EVENTS_RESOLUTION_SAMPLES}
             CLAP_ALWAYS_SPLIT_BLOCK=${CJA_CLAP_ALWAYS_SPLIT_BLOCK}
+            CLAP_USE_JUCE_PARAMETER_RANGES=${CJA_CLAP_USE_JUCE_PARAMETER_RANGES}
             )
 
     if(${CJA_IS_JUCER})

--- a/examples/GainPlugin/GainPlugin.cpp
+++ b/examples/GainPlugin/GainPlugin.cpp
@@ -75,10 +75,13 @@ void GainPlugin::handleDirectEvent(const clap_event_header_t *event, int /*sampl
         jassertfalse;
         return;
     }
-    
+
     // custom handling for parameter modulation events:
     auto paramModEvent = reinterpret_cast<const clap_event_param_mod *>(event);
-    auto *modulatableParam = static_cast<ModulatableFloatParameter *>(paramModEvent->cookie);
+    auto *parameterVariant = static_cast<JUCEParameterVariant *>(paramModEvent->cookie);
+    auto *modulatableParam =
+        reinterpret_cast<ModulatableFloatParameter *>(parameterVariant->processorParam);
+
     if (paramModEvent->note_id >= 0)
     {
         // no polyphonic modulation

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -91,7 +91,7 @@ struct clap_juce_audio_processor_capabilities
     /**
      * If your plugin returns true for supportsDirectEvent, then you'll need to
      * implement this method to actually handle that event when it comes along.
-     * 
+     *
      * @param event         The header for the incoming event.
      * @param sampleOffset  If the CLAP wrapper has split up the incoming buffer (e.g. to
      *                      apply sample-accurate automation), then you'll need to apply
@@ -188,7 +188,10 @@ class RangedAudioParameter;
 /** JUCE parameter that could be ranged, or could extend the clap_juce_parameter_capabilities */
 struct JUCEParameterVariant
 {
+    /** After the plugin has been initialized, this field should never be a nullptr! */
     juce::AudioProcessorParameter *processorParam = nullptr;
+
+    /** Depending on the underlying parameter type, these could be nullptr. */
     juce::RangedAudioParameter *rangedParameter = nullptr;
     clap_juce_extensions::clap_juce_parameter_capabilities *clapExtParameter = nullptr;
 };

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -179,4 +179,18 @@ struct clap_juce_parameter_capabilities
 };
 } // namespace clap_juce_extensions
 
+namespace juce
+{
+class AudioProcessorParameter;
+class RangedAudioParameter;
+} // namespace juce
+
+/** JUCE parameter that could be ranged, or could extend the clap_juce_parameter_capabilities */
+struct JUCEParameterVariant
+{
+    juce::AudioProcessorParameter *processorParam = nullptr;
+    juce::RangedAudioParameter *rangedParameter = nullptr;
+    clap_juce_extensions::clap_juce_parameter_capabilities *clapExtParameter = nullptr;
+};
+
 #endif // SURGE_CLAP_JUCE_EXTENSIONS_H

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -759,6 +759,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         strncpy(info->module, group.toRawUTF8(), CLAP_NAME_SIZE);
 
 #if CLAP_USE_JUCE_PARAMETER_RANGES
+        // For discrete parameters, JUCE uses ranges [0, N], so we'll report that
+        // range to the CLAP host. For non-discrete parameters, we'll report a [0, 1]
+        // range and let the parameter's normalisable range take care of everything.
         auto *rangedParam = paramVariant.rangedParameter;
         if (rangedParam && paramVariant.processorParam->isDiscrete())
         {

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -96,6 +96,14 @@ template <typename T, int qSize = 4096> class PushPopQ
     T dq[(size_t)qSize];
 };
 
+/** JUCE parameter that could be ranged, or could extend the clap_juce_parameter_capabilities */
+struct JUCEParameterVariant
+{
+    juce::AudioProcessorParameter *processorParam = nullptr;
+    juce::RangedAudioParameter *rangedParameter = nullptr;
+    clap_juce_extensions::clap_juce_parameter_capabilities *clapExtParameter = nullptr;
+};
+
 /*
  * These functions are the JUCE VST2/3 NSView attachment functions. We compile them into
  * our clap dll by, on macos, also linking clap_juce_mac.mm
@@ -123,6 +131,11 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC(4996) // allow strncpy
 
 #if !defined(CLAP_ALWAYS_SPLIT_BLOCK)
 #define CLAP_ALWAYS_SPLIT_BLOCK 0
+#endif
+
+#if !defined(CLAP_USE_JUCE_PARAMETER_RANGES)
+static_assert(false);
+#define CLAP_USE_JUCE_PARAMETER_RANGES 0
 #endif
 
 // This is useful for debugging overrides
@@ -199,7 +212,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
 
             jassert(allClapIDs.find(clapID) == allClapIDs.end());
             allClapIDs.insert(clapID);
-            paramPtrByClapID[clapID] = juceParam;
+            paramPtrByClapID[clapID] = JUCEParameterVariant{
+                juceParam, dynamic_cast<juce::RangedAudioParameter *>(juceParam),
+                dynamic_cast<clap_juce_extensions::clap_juce_parameter_capabilities *>(juceParam)};
             clapIDByParamPtr[juceParam] = clapID;
         }
     }
@@ -332,7 +347,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     }
 #endif
 
-    clap_id clapIdFromParameterIndex(int index)
+    clap_id clapIdFromParameterIndex(int index) const
     {
         auto pbi = juceParameters.getParamForIndex(index);
         auto pf = clapIDByParamPtr.find(pbi);
@@ -343,24 +358,36 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         return id;
     }
 
-    static float getCorrectedParameterValueFromUI(juce::AudioProcessorParameter *pbi, float value)
+    static float getUnNormalisedParameterValue(const JUCEParameterVariant &parameter, float value)
     {
+#if CLAP_USE_JUCE_PARAMETER_RANGES
         // The JUCE parameter gives us a value in the range [0, 1]
-        // but the CLAP host needs discrete parameters in the range [0, numSteps]
-        if (pbi->isDiscrete())
-            value *= float(pbi->getNumSteps() - 1);
+        // but the CLAP host needs discrete parameters in the range [0, N]
+        auto *rangedParam = parameter.rangedParameter;
+        if (rangedParam && parameter.processorParam->isDiscrete())
+            return rangedParam->convertFrom0to1(value);
 
         return value;
+#else
+        juce::ignoreUnused(parameter);
+        return value;
+#endif
     }
 
-    static float getCorrectedParameterValueFromHost(juce::AudioProcessorParameter *pbi, float value)
+    static float getNormalisedParameterValue(const JUCEParameterVariant &parameter, float value)
     {
-        // the CLAP host gives us the discrete parameter as [0, numSteps],
+#if CLAP_USE_JUCE_PARAMETER_RANGES
+        // the CLAP host gives us the discrete parameter as [0, N],
         // but we need to report the value to the JUCE parameter as [0, 1]
-        if (pbi->isDiscrete())
-            value /= float(pbi->getNumSteps() - 1);
+        auto *rangedParam = parameter.rangedParameter;
+        if (rangedParam && parameter.processorParam->isDiscrete())
+            return rangedParam->convertTo0to1(value);
 
         return value;
+#else
+        juce::ignoreUnused(parameter);
+        return value;
+#endif
     }
 
     bool supressParameterChangeMessages{false};
@@ -384,7 +411,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             return;
 
         auto id = clapIdFromParameterIndex(index);
-        newValue = getCorrectedParameterValueFromUI(paramPtrByClapID[id], newValue);
+        newValue = getUnNormalisedParameterValue(paramPtrByClapID[id], newValue);
         uiParamChangeQ.push({CLAP_EVENT_PARAM_VALUE, 0, id, newValue});
 
         if (_host.canUseParams())
@@ -394,8 +421,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     void audioProcessorParameterChangeGestureBegin(juce::AudioProcessor *, int index) override
     {
         auto id = clapIdFromParameterIndex(index);
-        auto *pbi = paramPtrByClapID[id];
-        auto value = getCorrectedParameterValueFromUI(pbi, pbi->getValue());
+        auto &pbi = paramPtrByClapID[id];
+        auto value = getUnNormalisedParameterValue(pbi, pbi.processorParam->getValue());
         uiParamChangeQ.push({CLAP_EVENT_PARAM_GESTURE_BEGIN, 0, id, value});
 
         if (_host.canUseParams())
@@ -405,8 +432,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     void audioProcessorParameterChangeGestureEnd(juce::AudioProcessor *, int index) override
     {
         auto id = clapIdFromParameterIndex(index);
-        auto *pbi = paramPtrByClapID[id];
-        auto value = getCorrectedParameterValueFromUI(pbi, pbi->getValue());
+        auto &pbi = paramPtrByClapID[id];
+        auto value = getUnNormalisedParameterValue(pbi, pbi.processorParam->getValue());
         uiParamChangeQ.push({CLAP_EVENT_PARAM_GESTURE_END, 0, id, value});
 
         if (_host.canUseParams())
@@ -708,9 +735,12 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     uint32_t paramsCount() const noexcept override { return (uint32_t)allClapIDs.size(); }
     bool paramsInfo(uint32_t paramIndex, clap_param_info *info) const noexcept override
     {
-        auto pbi = juceParameters.getParamForIndex((int)paramIndex);
+        const auto paramID = clapIdFromParameterIndex((int)paramIndex);
+        auto &paramVariant = paramPtrByClapID.at(paramID);
 
-        auto *parameterGroup = processor->getParameterTree().getGroupsForParameter(pbi).getLast();
+        auto *parameterGroup = processor->getParameterTree()
+                                   .getGroupsForParameter(paramVariant.processorParam)
+                                   .getLast();
         juce::String group = "";
         while (parameterGroup && parameterGroup->getParent() &&
                parameterGroup->getParent()->getName().isNotEmpty())
@@ -723,34 +753,43 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             group = "/" + group;
 
         // Fixme - using parameter groups here would be lovely but until then
-        info->id = generateClapIDForJuceParam(pbi);
-        strncpy(info->name, (pbi->getName(CLAP_NAME_SIZE)).toRawUTF8(), CLAP_NAME_SIZE);
+        info->id = paramID;
+        strncpy(info->name, (paramVariant.processorParam->getName(CLAP_NAME_SIZE)).toRawUTF8(),
+                CLAP_NAME_SIZE);
         strncpy(info->module, group.toRawUTF8(), CLAP_NAME_SIZE);
 
-        info->min_value = 0.0;
-        info->max_value = 1.0;
-        info->default_value = pbi->getDefaultValue();
-        info->cookie = pbi;
+#if CLAP_USE_JUCE_PARAMETER_RANGES
+        auto *rangedParam = paramVariant.rangedParameter;
+        if (rangedParam && paramVariant.processorParam->isDiscrete())
+        {
+            info->min_value = rangedParam->getNormalisableRange().start;
+            info->max_value = rangedParam->getNormalisableRange().end;
+            info->default_value =
+                rangedParam->convertFrom0to1(paramVariant.processorParam->getDefaultValue());
+        }
+        else
+#endif
+        {
+            info->min_value = 0.0;
+            info->max_value = 1.0;
+            info->default_value = paramVariant.processorParam->getDefaultValue();
+        }
+
+        info->cookie = const_cast<JUCEParameterVariant *>(&paramVariant);
         info->flags = 0;
 
         jassert(paramPtrByClapID.find(info->id) != paramPtrByClapID.end());
-        jassert(paramPtrByClapID.find(info->id)->second == info->cookie);
+        jassert(&paramPtrByClapID.find(info->id)->second == info->cookie);
 
-        if (pbi->isAutomatable())
+        if (paramVariant.processorParam->isAutomatable())
             info->flags = info->flags | CLAP_PARAM_IS_AUTOMATABLE;
 
-        if (pbi->isBoolean() || pbi->isDiscrete())
+        if (paramVariant.processorParam->isBoolean() || paramVariant.processorParam->isDiscrete())
         {
             info->flags = info->flags | CLAP_PARAM_IS_STEPPED;
-
-            if (auto *rangedParam = dynamic_cast<juce::RangedAudioParameter *>(pbi))
-            {
-                info->min_value = (double)rangedParam->getNormalisableRange().start;
-                info->max_value = (double)rangedParam->getNormalisableRange().end;
-            }
         }
 
-        auto cpc = dynamic_cast<clap_juce_extensions::clap_juce_parameter_capabilities *>(pbi);
+        auto *cpc = paramVariant.clapExtParameter;
         if (cpc)
         {
             if (cpc->supportsMonophonicModulation())
@@ -772,7 +811,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     bool paramsValue(clap_id paramId, double *value) noexcept override
     {
         auto pbi = paramPtrByClapID[paramId];
-        *value = getCorrectedParameterValueFromUI(pbi, pbi->getValue());
+        *value = getUnNormalisedParameterValue(pbi, pbi.processorParam->getValue());
         return true;
     }
 
@@ -780,11 +819,11 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                            uint32_t size) noexcept override
     {
         auto pbi = paramPtrByClapID[paramId];
-        value = (double) getCorrectedParameterValueFromHost(pbi, (float) value);
+        value = (double)getNormalisedParameterValue(pbi, (float)value);
 
         if (!usingLegacyParameterAPI)
         {
-            auto res = pbi->getText((float)value, (int)size);
+            auto res = pbi.processorParam->getText((float)value, (int)size);
             strncpy(display, res.toStdString().c_str(), size);
         }
         else
@@ -793,7 +832,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
              * This is really unsatisfactory but we have very little choice in the
              * event that the JUCE parameter mode is more or less like a VST2
              */
-            auto res = pbi->getCurrentValueAsText();
+            auto res = pbi.processorParam->getCurrentValueAsText();
             strncpy(display, res.toStdString().c_str(), size);
         }
 
@@ -803,7 +842,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     bool paramsTextToValue(clap_id paramId, const char *display, double *value) noexcept override
     {
         auto pbi = paramPtrByClapID[paramId];
-        *value = (double) getCorrectedParameterValueFromUI(pbi, pbi->getValueForText(display));
+        *value = (double)getUnNormalisedParameterValue(
+            pbi, pbi.processorParam->getValueForText(display));
         return true;
     }
 
@@ -811,25 +851,24 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     {
         auto nf = paramEvent->value;
         jassert(paramPtrByClapID.find(paramEvent->param_id) != paramPtrByClapID.end());
-        jassert(paramPtrByClapID.find(paramEvent->param_id)->second == paramEvent->cookie);
+        jassert(&paramPtrByClapID.find(paramEvent->param_id)->second == paramEvent->cookie);
 
-        auto jp = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
-
+        auto jp = static_cast<JUCEParameterVariant *>(paramEvent->cookie);
         paramSetValueAndNotifyIfChanged(*jp, (float)nf);
     }
 
-    void paramSetValueAndNotifyIfChanged(juce::AudioProcessorParameter &param, float newValue)
+    void paramSetValueAndNotifyIfChanged(JUCEParameterVariant &param, float newValue)
     {
-        newValue = getCorrectedParameterValueFromHost(&param, newValue);
+        newValue = getNormalisedParameterValue(param, newValue);
 
-        if (param.getValue() == newValue)
+        if (param.processorParam->getValue() == newValue)
             return;
 
-        param.setValue(newValue);
+        param.processorParam->setValue(newValue);
 
         // we want to trigger the parameter listener callbacks on the main thread,
         // but MessageManager::callAsync is not safe to call from the audio thread.
-        audioThreadParamListenerQ.push(ParamListenerCall{&param, newValue});
+        audioThreadParamListenerQ.push(ParamListenerCall{param.processorParam, newValue});
         _host.requestCallback();
     }
 
@@ -1453,7 +1492,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
      * Various maps for ID lookups
      */
     // clap_id to param *
-    std::unordered_map<clap_id, juce::AudioProcessorParameter *> paramPtrByClapID;
+    std::unordered_map<clap_id, JUCEParameterVariant> paramPtrByClapID;
     // param * to clap_id
     std::unordered_map<juce::AudioProcessorParameter *, clap_id> clapIDByParamPtr;
     // Every id we have issued

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -96,14 +96,6 @@ template <typename T, int qSize = 4096> class PushPopQ
     T dq[(size_t)qSize];
 };
 
-/** JUCE parameter that could be ranged, or could extend the clap_juce_parameter_capabilities */
-struct JUCEParameterVariant
-{
-    juce::AudioProcessorParameter *processorParam = nullptr;
-    juce::RangedAudioParameter *rangedParameter = nullptr;
-    clap_juce_extensions::clap_juce_parameter_capabilities *clapExtParameter = nullptr;
-};
-
 /*
  * These functions are the JUCE VST2/3 NSView attachment functions. We compile them into
  * our clap dll by, on macos, also linking clap_juce_mac.mm

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -126,7 +126,6 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC(4996) // allow strncpy
 #endif
 
 #if !defined(CLAP_USE_JUCE_PARAMETER_RANGES)
-static_assert(false);
 #define CLAP_USE_JUCE_PARAMETER_RANGES 0
 #endif
 


### PR DESCRIPTION
So I've hacked together a way to be able to get `juce::AudioParameterChoice` parameters working nicely with CLAP's `CLAP_PARAM_IS_STEPPED` property (it even passes the clap-validator tests!). Unfortunately, this implementation is very fragile... if the user has done implemented any sort of custom "discrete parameter" behaviour, this implementation won't work.

Really, I think we need to use the `NormalisableRange` for the parameter to convert to the un-normalised for the stepped parameters, but I haven't figured out a way to do that sort of thing that wouldn't require a ton of `dynamic_cast`s, and in parts of the code where performance really matters.

I'll keep thinking on it, but leave this here in the meantime...