### PR TITLE
Processor Capabilities: add methods for sending output events

### DIFF
--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -19,7 +19,9 @@ class ClapJuceWrapper;
 namespace juce
 {
 class MidiBuffer;
-}
+class AudioProcessorParameter;
+class RangedAudioParameter;
+} // namespace juce
 
 namespace clap_juce_extensions
 {
@@ -212,12 +214,6 @@ struct clap_juce_parameter_capabilities
     virtual bool supportsPolyphonicModulation() { return false; }
 };
 } // namespace clap_juce_extensions
-
-namespace juce
-{
-class AudioProcessorParameter;
-class RangedAudioParameter;
-} // namespace juce
 
 /** JUCE parameter that could be ranged, or could extend the clap_juce_parameter_capabilities */
 struct JUCEParameterVariant

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -15,6 +15,12 @@
 /** Forward declaration of the wrapper class. */
 class ClapJuceWrapper;
 
+/** Forward declarations for any JUCE classes we might need. */
+namespace juce
+{
+class MidiBuffer;
+}
+
 namespace clap_juce_extensions
 {
 /*
@@ -113,13 +119,19 @@ struct clap_juce_audio_processor_capabilities
      * called after your `processBlock()` method, so that any outbound events can be
      * added to the output event queue.
      *
+     * NOTE: if your plugin produces MIDI, you must take care to make sure that any outgoing
+     * events which are not MIDI events are correctly interleaved with the outgoing events
+     * from the midiBuffer, such that all the events in the output queue are ordered sequentially.
+     *
      * @param out_events    The output event queue.
+     * @param midiBuffer    The JUCE MIDI Buffer from the previous `processBlock()` call.
      * @param sampleOffset  If the CLAP wrapper has split up the incoming buffer, then
      *                      you'll need to apply this sample offset to the timestamp of
      *                      the outgoing event. For example:
      *                      `auto eventTime = eventTimeRelativeToStartOfLastBlock + sampleOffset;`
      */
     virtual void addOutboundEventsToQueue(const clap_output_events * /*out_events*/,
+                                          const juce::MidiBuffer & /* midiBuffer */,
                                           int /*sampleOffset*/)
     {
     }

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -104,7 +104,7 @@ struct clap_juce_audio_processor_capabilities
 
     /**
      * If your plugin needs to send outbound events (for example, telling the host that a
-     * note has ended, you should override this method to return true.
+     * note has ended), you should override this method to return true.
      */
     virtual bool supportsOutboundEvents() { return false; }
 
@@ -114,10 +114,9 @@ struct clap_juce_audio_processor_capabilities
      * added to the output event queue.
      *
      * @param out_events    The output event queue.
-     * @param sampleOffset  If the CLAP wrapper has split up the incoming buffer (e.g. to
-     *                      apply sample-accurate automation), then you'll need to apply
-     *                      this sample offset to the timestamp of the outgoing event
-     *                      to the block size being used by the host. For example:
+     * @param sampleOffset  If the CLAP wrapper has split up the incoming buffer, then
+     *                      you'll need to apply this sample offset to the timestamp of
+     *                      the outgoing event. For example:
      *                      `auto eventTime = eventTimeRelativeToStartOfLastBlock + sampleOffset;`
      */
     virtual void addOutboundEventsToQueue(const clap_output_events * /*out_events*/,

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -102,6 +102,29 @@ struct clap_juce_audio_processor_capabilities
      */
     virtual void handleDirectEvent(const clap_event_header_t * /*event*/, int /*sampleOffset*/) {}
 
+    /**
+     * If your plugin needs to send outbound events (for example, telling the host that a
+     * note has ended, you should override this method to return true.
+     */
+    virtual bool supportsOutboundEvents() { return false; }
+
+    /**
+     * If your plugin returns true for supportsOutboundEvents, then this method will be
+     * called after your `processBlock()` method, so that any outbound events can be
+     * added to the output event queue.
+     *
+     * @param out_events    The output event queue.
+     * @param sampleOffset  If the CLAP wrapper has split up the incoming buffer (e.g. to
+     *                      apply sample-accurate automation), then you'll need to apply
+     *                      this sample offset to the timestamp of the outgoing event
+     *                      to the block size being used by the host. For example:
+     *                      `auto eventTime = eventTimeRelativeToStartOfLastBlock + sampleOffset;`
+     */
+    virtual void addOutboundEventsToQueue(const clap_output_events * /*out_events*/,
+                                          int /*sampleOffset*/)
+    {
+    }
+
     /*
      * The JUCE process loop makes it difficult to do things like note expressions,
      * sample accurate parameter automation, and other CLAP features. The custom event handlers

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1084,14 +1084,12 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 processor->processBlock(buffer, midiBuffer);
             }
 
-            // @TODO: I think this is correct, but ask Paul if this should go after the
-            // "producesMidi()" bit?
             if (processorAsClapExtensions && processorAsClapExtensions->supportsOutboundEvents())
             {
-                processorAsClapExtensions->addOutboundEventsToQueue(process->out_events, n);
+                processorAsClapExtensions->addOutboundEventsToQueue(process->out_events, midiBuffer,
+                                                                    n);
             }
-
-            if (processor->producesMidi())
+            else if (processor->producesMidi())
             {
                 for (auto meta : midiBuffer)
                 {

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1084,6 +1084,13 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 processor->processBlock(buffer, midiBuffer);
             }
 
+            // @TODO: I think this is correct, but ask Paul if this should go after the
+            // "producesMidi()" bit?
+            if (processorAsClapExtensions && processorAsClapExtensions->supportsOutboundEvents())
+            {
+                processorAsClapExtensions->addOutboundEventsToQueue(process->out_events, n);
+            }
+
             if (processor->producesMidi())
             {
                 for (auto meta : midiBuffer)


### PR DESCRIPTION
Adding methods to `clap_juce_audio_processor_capabilities` so that CLAP plugins can send output events to the host. For the moment, I think the only plugin we can test this is Surge, so I've made a [test branch](https://github.com/surge-synthesizer/surge/compare/main...Chowdhury-DSP:surge:clap-poly-mod-without-direct-process) of Surge to try it out.
