### PR TITLE
Fixes so that more JUCE plugs pass clap-validator

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -365,7 +365,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
 
         auto id = clapIdFromParameterIndex(index);
         uiParamChangeQ.push({CLAP_EVENT_PARAM_VALUE, 0, id, newValue});
-        _host.paramsRequestFlush();
+
+        if (_host.canUseParams())
+            _host.paramsRequestFlush();
     }
 
     void audioProcessorParameterChangeGestureBegin(juce::AudioProcessor *, int index) override
@@ -373,7 +375,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         auto id = clapIdFromParameterIndex(index);
         auto p = paramPtrByClapID[id];
         uiParamChangeQ.push({CLAP_EVENT_PARAM_GESTURE_BEGIN, 0, id, p->getValue()});
-        _host.paramsRequestFlush();
+
+        if (_host.canUseParams())
+            _host.paramsRequestFlush();
     }
 
     void audioProcessorParameterChangeGestureEnd(juce::AudioProcessor *, int index) override
@@ -381,7 +385,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         auto id = clapIdFromParameterIndex(index);
         auto p = paramPtrByClapID[id];
         uiParamChangeQ.push({CLAP_EVENT_PARAM_GESTURE_END, 0, id, p->getValue()});
-        _host.paramsRequestFlush();
+
+        if (_host.canUseParams())
+            _host.paramsRequestFlush();
     }
 
 #if JUCE_VERSION < 0x070000
@@ -773,7 +779,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     void handleParameterChangeEvent(const clap_event_param_value *paramEvent)
     {
         auto nf = paramEvent->value;
-        jassert(paramEvent->cookie == paramPtrByClapID[paramEvent->param_id]);
+        jassert(paramPtrByClapID.find(paramEvent->param_id) != paramPtrByClapID.end());
+        jassert(paramPtrByClapID.find(paramEvent->param_id)->second == paramEvent->cookie);
+
         auto jp = static_cast<juce::AudioProcessorParameter *>(paramEvent->cookie);
 
         paramSetValueAndNotifyIfChanged(*jp, (float)nf);

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1032,14 +1032,15 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         pushUIQueueToOutputEvents(out);
 
         uint32_t sz = in->size(in);
-        for (uint32_t i=0; i<sz; ++i)
+        for (uint32_t i = 0; i < sz; ++i)
         {
             auto ev = in->get(in, i);
             process_clap_event(ev, 0); // 0 since there is no block decomp in flush
         }
     }
 
-    void pushUIQueueToOutputEvents(const clap_output_events_t *ov) {
+    void pushUIQueueToOutputEvents(const clap_output_events_t *ov)
+    {
         auto pc = ParamChange();
         while (uiParamChangeQ.pop(pc))
         {
@@ -1133,7 +1134,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         break;
         default:
         {
-            DBG("Unknown message type " << (int)event->type);
+            DBG("Unknown CLAP Event type " << (int)event->type);
             // In theory I should never get this.
             // jassertfalse
         }
@@ -1321,7 +1322,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
 
         auto dat = (uint8_t *)chunkMemory.getData();
         auto sz = chunkMemory.getSize();
-        while (sz > 0)
+        auto sofar = 0U;
+        while (sofar < sz)
         {
             auto written = stream->write(stream, dat, sz);
             if (written < 0)
@@ -1329,9 +1331,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 return false;
             }
             dat += written;
-            sz -= written;
+            sofar += (uint32_t)written;
         }
-        return sz == 0;
+        return sz == sofar;
     }
     bool stateLoad(const clap_istream *stream) noexcept override
     {
@@ -1435,7 +1437,6 @@ clap_plugin_descriptor ClapJuceWrapper::desc = {CLAP_VERSION,
                                                 JucePlugin_VersionString,
                                                 JucePlugin_Desc,
                                                 features};
-
 
 JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE("-Wredundant-decls")
 juce::AudioProcessor *JUCE_CALLTYPE createPluginFilter();

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1333,7 +1333,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         auto sofar = 0U;
         while (sofar < sz)
         {
-            auto written = stream->write(stream, dat, (uint32_t)((int)sz - sofar));
+            auto written = stream->write(stream, dat, (uint32_t)(sz - sofar));
             if (written < 0)
             {
                 return false;

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1325,7 +1325,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         auto sofar = 0U;
         while (sofar < sz)
         {
-            auto written = stream->write(stream, dat, sz);
+            auto written = stream->write(stream, dat, (uint32_t)((int)sz - sofar));
             if (written < 0)
             {
                 return false;


### PR DESCRIPTION
1. Implment write in chunks as opposed to assume full write works
2. Implmenet paramFlush properly; refactor events slightly to avoid
   duplicatin in doing so.