### PR TITLE
Parameter Capabilities: apply parameter modulation from inside the JUCE wrapper

### DIFF
--- a/examples/GainPlugin/GainPlugin.cpp
+++ b/examples/GainPlugin/GainPlugin.cpp
@@ -59,56 +59,6 @@ void GainPlugin::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuffer
     gain.process(juce::dsp::ProcessContextReplacing<float>{block});
 }
 
-// bool GainPlugin::supportsDirectEvent(uint16_t space_id, uint16_t type)
-//{
-//     if (space_id != CLAP_CORE_EVENT_SPACE_ID)
-//         return false;
-//
-//     return type == CLAP_EVENT_PARAM_MOD; // custom handling for parameter modulation events only
-// }
-//
-// void GainPlugin::handleDirectEvent(const clap_event_header_t *event, int /*sampleOffset*/)
-//{
-//     if (event->space_id != CLAP_CORE_EVENT_SPACE_ID || event->type != CLAP_EVENT_PARAM_MOD)
-//     {
-//         // we should not be receiving events of this type!
-//         jassertfalse;
-//         return;
-//     }
-//
-//     // custom handling for parameter modulation events:
-//     auto paramModEvent = reinterpret_cast<const clap_event_param_mod *>(event);
-//     auto *parameterVariant = static_cast<JUCEParameterVariant *>(paramModEvent->cookie);
-//
-//     if (auto *modulatableParam = parameterVariant->clapExtParameter)
-//     {
-//         if (paramModEvent->note_id >= 0)
-//         {
-//             if (!modulatableParam->supportsPolyphonicModulation())
-//             {
-//                 // The host is misbehaving! The host should know that this parameter does not
-//                 // support polyphonic modulation, and should not have sent this event.
-//                 jassertfalse;
-//                 return;
-//             }
-//
-//             // no polyphonic modulation at this time
-//         }
-//         else
-//         {
-//             if (!modulatableParam->supportsMonophonicModulation())
-//             {
-//                 // The host is misbehaving! The host should know that this parameter does not
-//                 // support monophonic modulation, and should not have sent this event.
-//                 jassertfalse;
-//                 return;
-//             }
-//
-//             modulatableParam->applyMonophonicModulation(paramModEvent->amount);
-//         }
-//     }
-// }
-
 juce::AudioProcessorEditor *GainPlugin::createEditor() { return new PluginEditor(*this); }
 
 juce::String GainPlugin::getPluginTypeString() const

--- a/examples/GainPlugin/GainPlugin.cpp
+++ b/examples/GainPlugin/GainPlugin.cpp
@@ -59,55 +59,55 @@ void GainPlugin::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuffer
     gain.process(juce::dsp::ProcessContextReplacing<float>{block});
 }
 
-bool GainPlugin::supportsDirectEvent(uint16_t space_id, uint16_t type)
-{
-    if (space_id != CLAP_CORE_EVENT_SPACE_ID)
-        return false;
-
-    return type == CLAP_EVENT_PARAM_MOD; // custom handling for parameter modulation events only
-}
-
-void GainPlugin::handleDirectEvent(const clap_event_header_t *event, int /*sampleOffset*/)
-{
-    if (event->space_id != CLAP_CORE_EVENT_SPACE_ID || event->type != CLAP_EVENT_PARAM_MOD)
-    {
-        // we should not be receiving events of this type!
-        jassertfalse;
-        return;
-    }
-
-    // custom handling for parameter modulation events:
-    auto paramModEvent = reinterpret_cast<const clap_event_param_mod *>(event);
-    auto *parameterVariant = static_cast<JUCEParameterVariant *>(paramModEvent->cookie);
-
-    if (auto *modulatableParam = parameterVariant->clapExtParameter)
-    {
-        if (paramModEvent->note_id >= 0)
-        {
-            if (!modulatableParam->supportsPolyphonicModulation())
-            {
-                // The host is misbehaving! The host should know that this parameter does not
-                // support polyphonic modulation, and should not have sent this event.
-                jassertfalse;
-                return;
-            }
-
-            // no polyphonic modulation at this time
-        }
-        else
-        {
-            if (!modulatableParam->supportsMonophonicModulation())
-            {
-                // The host is misbehaving! The host should know that this parameter does not
-                // support monophonic modulation, and should not have sent this event.
-                jassertfalse;
-                return;
-            }
-
-            modulatableParam->applyMonophonicModulation(paramModEvent->amount);
-        }
-    }
-}
+// bool GainPlugin::supportsDirectEvent(uint16_t space_id, uint16_t type)
+//{
+//     if (space_id != CLAP_CORE_EVENT_SPACE_ID)
+//         return false;
+//
+//     return type == CLAP_EVENT_PARAM_MOD; // custom handling for parameter modulation events only
+// }
+//
+// void GainPlugin::handleDirectEvent(const clap_event_header_t *event, int /*sampleOffset*/)
+//{
+//     if (event->space_id != CLAP_CORE_EVENT_SPACE_ID || event->type != CLAP_EVENT_PARAM_MOD)
+//     {
+//         // we should not be receiving events of this type!
+//         jassertfalse;
+//         return;
+//     }
+//
+//     // custom handling for parameter modulation events:
+//     auto paramModEvent = reinterpret_cast<const clap_event_param_mod *>(event);
+//     auto *parameterVariant = static_cast<JUCEParameterVariant *>(paramModEvent->cookie);
+//
+//     if (auto *modulatableParam = parameterVariant->clapExtParameter)
+//     {
+//         if (paramModEvent->note_id >= 0)
+//         {
+//             if (!modulatableParam->supportsPolyphonicModulation())
+//             {
+//                 // The host is misbehaving! The host should know that this parameter does not
+//                 // support polyphonic modulation, and should not have sent this event.
+//                 jassertfalse;
+//                 return;
+//             }
+//
+//             // no polyphonic modulation at this time
+//         }
+//         else
+//         {
+//             if (!modulatableParam->supportsMonophonicModulation())
+//             {
+//                 // The host is misbehaving! The host should know that this parameter does not
+//                 // support monophonic modulation, and should not have sent this event.
+//                 jassertfalse;
+//                 return;
+//             }
+//
+//             modulatableParam->applyMonophonicModulation(paramModEvent->amount);
+//         }
+//     }
+// }
 
 juce::AudioProcessorEditor *GainPlugin::createEditor() { return new PluginEditor(*this); }
 

--- a/examples/GainPlugin/GainPlugin.h
+++ b/examples/GainPlugin/GainPlugin.h
@@ -32,9 +32,6 @@ class GainPlugin : public juce::AudioProcessor,
     void processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) override;
     void processBlock(juce::AudioBuffer<double> &, juce::MidiBuffer &) override {}
 
-    //    bool supportsDirectEvent(uint16_t space_id, uint16_t type) override;
-    //    void handleDirectEvent(const clap_event_header_t *event, int sampleOffset) override;
-
     bool hasEditor() const override { return true; }
     juce::AudioProcessorEditor *createEditor() override;
 

--- a/examples/GainPlugin/GainPlugin.h
+++ b/examples/GainPlugin/GainPlugin.h
@@ -32,8 +32,8 @@ class GainPlugin : public juce::AudioProcessor,
     void processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) override;
     void processBlock(juce::AudioBuffer<double> &, juce::MidiBuffer &) override {}
 
-    bool supportsDirectEvent(uint16_t space_id, uint16_t type) override;
-    void handleDirectEvent(const clap_event_header_t *event, int sampleOffset) override;
+    //    bool supportsDirectEvent(uint16_t space_id, uint16_t type) override;
+    //    void handleDirectEvent(const clap_event_header_t *event, int sampleOffset) override;
 
     bool hasEditor() const override { return true; }
     juce::AudioProcessorEditor *createEditor() override;

--- a/examples/GainPlugin/ModulatableFloatParameter.h
+++ b/examples/GainPlugin/ModulatableFloatParameter.h
@@ -40,7 +40,7 @@ class ModulatableFloatParameter : public juce::AudioParameterFloat,
 
     bool supportsMonophonicModulation() override { return true; }
 
-    void applyMonophonicModulation(double modulationValue)
+    void applyMonophonicModulation(double modulationValue) override
     {
         modulationAmount = (float)modulationValue;
     }

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -54,6 +54,8 @@ struct clap_properties
  */
 struct clap_juce_audio_processor_capabilities
 {
+    virtual ~clap_juce_audio_processor_capabilities() = default;
+
     /*
      * In some cases, there is no main input, and input 0 is not main. Allow your plugin
      * to advertise that. (This case is usually for synths with sidechains).
@@ -197,6 +199,8 @@ struct clap_juce_audio_processor_capabilities
  */
 struct clap_juce_parameter_capabilities
 {
+    virtual ~clap_juce_parameter_capabilities() = default;
+
     /*
      * Return true if this parameter should receive non-destructive
      * monophonic modulation rather than simple setValue when a DAW
@@ -208,10 +212,10 @@ struct clap_juce_parameter_capabilities
     virtual void applyMonophonicModulation(double /*amount*/) {}
 
     /*
-     * Return true if this parameter should receive non-destructive
-     * polyphonic modulation. As well as supporting the monophonic case
-     * this also requires your process to return note end events when
-     * voices are terminated.
+     * Return true if this parameter should receive non-destructive polyphonic modulation. If this
+     * method returns true, then the host will also expect that the paramter can handle monophonic
+     * modulation. Additionally, your plugin must return note end events when notes are terminated,
+     * by implementing either `addOutboundEventsToQueue()` or `clap_direct_process()`.
      */
     virtual bool supportsPolyphonicModulation() { return false; }
 

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -85,11 +85,11 @@ struct clap_juce_audio_processor_capabilities
      * - MIDI note on/off events
      * - MIDI CC events
      * - Parameter change events
+     * - Parameter modulation events
      *
-     * If you would like to handle these events using some custom behaviour, or
-     * if you would like to handle other CLAP events (e.g. parameter modulation or
-     * note expression), or events from another namespace, you should override
-     * this method to return true for those event types.
+     * If you would like to handle these events using some custom behaviour, or if you would like
+     * to handle other CLAP events (e.g. note expression), or events from another namespace, you
+     * should override this method to return true for those event types.
      *
      * @param space_id  The namespace ID for the given event.
      * @param type      The event type.
@@ -200,17 +200,11 @@ struct clap_juce_parameter_capabilities
     /*
      * Return true if this parameter should receive non-destructive
      * monophonic modulation rather than simple setValue when a DAW
-     * initiated modulation changes. Requires you to implement
-     * either clap_direct_process or handleDirectEvent.
+     * initiated modulation changes.
      */
     virtual bool supportsMonophonicModulation() { return false; }
 
-    /**
-     * Since the `clap_juce_parameter_capabilities` can be accessed directly from the
-     * `cookie` attached to each parameter event, it can be convenient to implement this
-     * method for your modulation-capable parameters, so you can call this method directly,
-     * rather than having to up-cast to your custom parameter type.
-     */
+    /** Implement this method to apply the parameter modulation event to your parameter. */
     virtual void applyMonophonicModulation(double /*amount*/) {}
 
     /*
@@ -221,7 +215,7 @@ struct clap_juce_parameter_capabilities
      */
     virtual bool supportsPolyphonicModulation() { return false; }
 
-    /** Polyphonic version of applyMonophonicModulation(). */
+    /** Implement this method to apply the parameter modulation event to your parameter. */
     virtual void applyPolyphonicModulation(int32_t /*note_id*/, int16_t /*port_index*/,
                                            int16_t /*channel*/, int16_t /*key*/, double /*amount*/)
     {

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -201,9 +201,17 @@ struct clap_juce_parameter_capabilities
      * Return true if this parameter should receive non-destructive
      * monophonic modulation rather than simple setValue when a DAW
      * initiated modulation changes. Requires you to implement
-     * clap_direct_process
+     * either clap_direct_process or handleDirectEvent.
      */
     virtual bool supportsMonophonicModulation() { return false; }
+
+    /**
+     * Since the `clap_juce_parameter_capabilities` can be accessed directly from the
+     * `cookie` attached to each parameter event, it can be convenient to implement this
+     * method for your modulation-capable parameters, so you can call this method directly,
+     * rather than having to up-cast to your custom parameter type.
+     */
+    virtual void applyMonophonicModulation(double /*amount*/) {}
 
     /*
      * Return true if this parameter should receive non-destructive
@@ -212,10 +220,21 @@ struct clap_juce_parameter_capabilities
      * voices are terminated.
      */
     virtual bool supportsPolyphonicModulation() { return false; }
+
+    /** Polyphonic version of applyMonophonicModulation(). */
+    virtual void applyPolyphonicModulation(int32_t /*note_id*/, int16_t /*port_index*/,
+                                           int16_t /*channel*/, int16_t /*key*/, double /*amount*/)
+    {
+    }
 };
 } // namespace clap_juce_extensions
 
-/** JUCE parameter that could be ranged, or could extend the clap_juce_parameter_capabilities */
+/**
+ * JUCE parameter that could be ranged, or could extend the clap_juce_parameter_capabilities.
+ *
+ * When handling CLAP parameter events (e.g. CLAP_EVENT_PARAM_VALUE or CLAP_EVENT_PARAM_MOD),
+ * the event `cookie` will be a `JUCEParameterVariant*`.
+ */
 struct JUCEParameterVariant
 {
     /** After the plugin has been initialized, this field should never be a nullptr! */


### PR DESCRIPTION
So this is kind of cool: it turns out our changes in #90 also make it possible for the JUCE wrapper to apply parameter modulation events directly! This way, if a JUCE plugin wants to do monophonic modulation, all it has to do is implement `clap_juce_parameter_capabilities`, and the wrapper can handle the rest.