### PR TITLE
Fix so Linux Projucer Gain plugin works

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -244,7 +244,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     void onTimer(clap_id timerId) noexcept override
     {
         juce::ignoreUnused(timerId);
-#if LINUX
+#if JUCE_LINUX
         juce::ScopedJuceInitialiser_GUI libraryInitialiser;
         const juce::MessageManagerLock mmLock;
 


### PR DESCRIPTION
Which really is the annoying fire-the-timer ifdef fix because we conflated LINUX and JUCE_LINUX ifdefs