### PR TITLE
Remove dead comment in build-projucer.yml

### DIFF
--- a/.github/workflows/build-projucer.yml
+++ b/.github/workflows/build-projucer.yml
@@ -118,7 +118,7 @@ jobs:
           cmake --build build --config Release --parallel 4
 
       - name: Run clap-info (Max/Linux)
-        if: runner.os == 'MacOS' || runner.os == 'Linux'  # @TODO: figure out why `clap_entry` returns nullptr for Linux Projucer builds - it's freetype
+        if: runner.os == 'MacOS' || runner.os == 'Linux'
         shell: bash
         run: |
           clap-info/build/clap-info --version


### PR DESCRIPTION
Linux Projucer builds are now working with clap-info, so removing a comment from the CI script saying that is doesn't work.