### PR TITLE
Expose note names extension to plugins

### DIFF
--- a/.github/workflows/build-projucer.yml
+++ b/.github/workflows/build-projucer.yml
@@ -33,7 +33,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt install libasound2-dev libcurl4-openssl-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev libjack-jackd2-dev
+          sudo apt install libasound2-dev libcurl4-openssl-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev libjack-jackd2-dev libxml2-utils
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,3 +16,4 @@ if(CLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS)
 endif()
 
 add_subdirectory(GainPlugin)
+add_subdirectory(NoteNamesPlugin)

--- a/examples/NoteNamesPlugin/CMakeLists.txt
+++ b/examples/NoteNamesPlugin/CMakeLists.txt
@@ -1,0 +1,68 @@
+if(CLAP_WRAP_PROJUCER_PLUGIN)
+    set(PATH_TO_JUCE "${JUCE_SOURCE_DIR}")
+    set(PATH_TO_CLAP_EXTENSIONS ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+
+    if(APPLE)
+        set(JUCER_GENERATOR "Xcode")
+    elseif(WIN32)
+        set(JUCER_GENERATOR "VisualStudio2019")
+    else() # Linux
+        set(JUCER_GENERATOR "LinuxMakefile")
+    endif()
+
+    include(${PATH_TO_CLAP_EXTENSIONS}/cmake/JucerClap.cmake)
+    create_jucer_clap_target(
+        TARGET "NoteNamesPlugin"
+        PLUGIN_NAME "NoteNamesPlugin"
+        BINARY_NAME "NoteNamesPlugin"
+        PLUGIN_CODE "NNpg"
+        MANUFACTURER_NAME "${COMPANY_NAME}"
+        MANUFACTURER_CODE "${COMPANY_CODE}"
+        VERSION_STRING "${CMAKE_PROJECT_VERSION}"
+        CLAP_ID "org.free-audio.NoteNamesPlugin"
+        CLAP_FEATURES audio-effect utility
+    )
+
+    return()
+endif()
+
+juce_add_plugin(NoteNamesPlugin
+    COMPANY_NAME "${COMPANY_NAME}"
+    PLUGIN_MANUFACTURER_CODE "${COMPANY_CODE}"
+    PLUGIN_CODE Gplg
+    FORMATS ${JUCE_FORMATS}
+    PRODUCT_NAME "NoteNamesPlugin"
+    IS_SYNTH TRUE
+)
+
+clap_juce_extensions_plugin(
+    TARGET NoteNamesPlugin
+    CLAP_ID "org.free-audio.NoteNamesPlugin"
+    CLAP_FEATURES audio-effect utility
+)
+
+target_sources(NoteNamesPlugin PRIVATE
+    NoteNamesPlugin.cpp
+)
+
+target_compile_definitions(NoteNamesPlugin PUBLIC
+    JUCE_DISPLAY_SPLASH_SCREEN=1
+    JUCE_REPORT_APP_USAGE=0
+    JUCE_WEB_BROWSER=0
+    JUCE_USE_CURL=0
+    JUCE_JACK=1
+    JUCE_ALSA=1
+    JUCE_MODAL_LOOPS_PERMITTED=1 # required for Linux FileChooser with JUCE 6.0.7
+    JUCE_VST3_CAN_REPLACE_VST2=0
+)
+
+target_link_libraries(NoteNamesPlugin
+    PRIVATE
+        juce::juce_audio_utils
+        juce::juce_audio_plugin_client
+        clap_juce_extensions
+    PUBLIC
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_lto_flags
+        juce::juce_recommended_warning_flags
+)

--- a/examples/NoteNamesPlugin/CMakeLists.txt
+++ b/examples/NoteNamesPlugin/CMakeLists.txt
@@ -1,28 +1,4 @@
 if(CLAP_WRAP_PROJUCER_PLUGIN)
-    set(PATH_TO_JUCE "${JUCE_SOURCE_DIR}")
-    set(PATH_TO_CLAP_EXTENSIONS ${CMAKE_CURRENT_SOURCE_DIR}/../..)
-
-    if(APPLE)
-        set(JUCER_GENERATOR "Xcode")
-    elseif(WIN32)
-        set(JUCER_GENERATOR "VisualStudio2019")
-    else() # Linux
-        set(JUCER_GENERATOR "LinuxMakefile")
-    endif()
-
-    include(${PATH_TO_CLAP_EXTENSIONS}/cmake/JucerClap.cmake)
-    create_jucer_clap_target(
-        TARGET "NoteNamesPlugin"
-        PLUGIN_NAME "NoteNamesPlugin"
-        BINARY_NAME "NoteNamesPlugin"
-        PLUGIN_CODE "NNpg"
-        MANUFACTURER_NAME "${COMPANY_NAME}"
-        MANUFACTURER_CODE "${COMPANY_CODE}"
-        VERSION_STRING "${CMAKE_PROJECT_VERSION}"
-        CLAP_ID "org.free-audio.NoteNamesPlugin"
-        CLAP_FEATURES audio-effect utility
-    )
-
     return()
 endif()
 

--- a/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
@@ -1,0 +1,86 @@
+#include "NoteNamesPlugin.h"
+
+namespace
+{
+const juce::String noteNamesParamTag = "note_names";
+}
+
+NoteNamesPlugin::NoteNamesPlugin()
+    : juce::AudioProcessor(
+          BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)),
+      vts(*this, nullptr, juce::Identifier("Parameters"), createParameters()),
+      noteNamesParamAttachment(*vts.getParameter(noteNamesParamTag),
+                               [this](float) { noteNamesChanged(); }),
+      noteNamesParam(vts.getRawParameterValue(noteNamesParamTag))
+{
+    noteMaps[1] = {
+        {60, "Do"}, {62, "Re"}, {64, "Mi"}, {65, "Fa"},
+        {67, "So"}, {69, "La"}, {71, "Ti"}, {72, "Do"},
+    };
+    noteMaps[2] = {{60, "1"},     {61, "#9"}, {62, "2"},  {63, "b3"}, {64, "3"},  {65, "4"},
+                   {66, "BLUES"}, {67, "5"},  {68, "b6"}, {69, "6"},  {70, "b7"}, {71, "7"}};
+}
+
+juce::AudioProcessorValueTreeState::ParameterLayout NoteNamesPlugin::createParameters()
+{
+    std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
+
+    params.push_back(std::make_unique<juce::AudioParameterChoice>(
+        noteNamesParamTag, "Note Names", juce::StringArray{"None", "Do Re Mi", "Jazz?"}, 0));
+
+    return {params.begin(), params.end()};
+}
+
+int NoteNamesPlugin::noteNameCount() noexcept
+{
+    const auto noteNamesIndex = static_cast<size_t>(noteNamesParam->load());
+    return (int)noteMaps[noteNamesIndex].size();
+}
+
+bool NoteNamesPlugin::noteNameGet(int index, clap_note_name *noteName) noexcept
+{
+    const auto noteNamesIndex = static_cast<size_t>(noteNamesParam->load());
+    const auto &noteMap = noteMaps[noteNamesIndex];
+    if (index < (int)noteMap.size())
+    {
+        const auto &note = noteMap[(size_t)index];
+        strcpy(noteName->name, note.name.getCharPointer());
+        noteName->key = (int16_t)note.key;
+        return true;
+    }
+
+    return false;
+}
+
+bool NoteNamesPlugin::isBusesLayoutSupported(const juce::AudioProcessor::BusesLayout &) const
+{
+    return true;
+}
+
+void NoteNamesPlugin::prepareToPlay(double, int) {}
+
+void NoteNamesPlugin::processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) {}
+
+juce::AudioProcessorEditor *NoteNamesPlugin::createEditor()
+{
+    return new juce::GenericAudioProcessorEditor{*this};
+}
+
+void NoteNamesPlugin::getStateInformation(juce::MemoryBlock &data)
+{
+    auto state = vts.copyState();
+    std::unique_ptr<juce::XmlElement> xml(state.createXml());
+    copyXmlToBinary(*xml, data);
+}
+
+void NoteNamesPlugin::setStateInformation(const void *data, int sizeInBytes)
+{
+    std::unique_ptr<juce::XmlElement> xmlState(getXmlFromBinary(data, sizeInBytes));
+
+    if (xmlState != nullptr)
+        if (xmlState->hasTagName(vts.state.getType()))
+            vts.replaceState(juce::ValueTree::fromXml(*xmlState));
+}
+
+// This creates new instances of the plugin
+juce::AudioProcessor *JUCE_CALLTYPE createPluginFilter() { return new NoteNamesPlugin(); }

--- a/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
@@ -13,6 +13,10 @@ NoteNamesPlugin::NoteNamesPlugin()
                                [this](float) { noteNamesChanged(); }),
       noteNamesParam(vts.getRawParameterValue(noteNamesParamTag))
 {
+    // At the moment, this has only been tested in Bitwig, where it works with some limitations
+    // (see https://github.com/free-audio/interop-tracker/issues/46). It would probably be good
+    // to do some tests with Reaper and some other hosts as well.
+
     noteMaps[0] = {
         {60, "C"}, {62, "D"}, {64, "E"}, {65, "F"}, {67, "G"}, {69, "A"}, {71, "B"}, {72, "C"},
     };

--- a/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
@@ -13,12 +13,16 @@ NoteNamesPlugin::NoteNamesPlugin()
                                [this](float) { noteNamesChanged(); }),
       noteNamesParam(vts.getRawParameterValue(noteNamesParamTag))
 {
+    noteMaps[0] = {
+        {60, "C"}, {62, "D"}, {64, "E"}, {65, "F"}, {67, "G"}, {69, "A"}, {71, "B"}, {72, "C"},
+    };
     noteMaps[1] = {
         {60, "Do"}, {62, "Re"}, {64, "Mi"}, {65, "Fa"},
         {67, "So"}, {69, "La"}, {71, "Ti"}, {72, "Do"},
     };
-    noteMaps[2] = {{60, "1"},     {61, "#9"}, {62, "2"},  {63, "b3"}, {64, "3"},  {65, "4"},
-                   {66, "BLUES"}, {67, "5"},  {68, "b6"}, {69, "6"},  {70, "b7"}, {71, "7"}};
+    noteMaps[2] = {
+        {60, "1"}, {62, "2"}, {64, "3"}, {65, "4"}, {67, "5"}, {69, "6"}, {71, "7"}, {72, "8"},
+    };
 }
 
 juce::AudioProcessorValueTreeState::ParameterLayout NoteNamesPlugin::createParameters()
@@ -26,7 +30,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout NoteNamesPlugin::createParam
     std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
 
     params.push_back(std::make_unique<juce::AudioParameterChoice>(
-        noteNamesParamTag, "Note Names", juce::StringArray{"None", "Do Re Mi", "Jazz?"}, 0));
+        noteNamesParamTag, "Note Names", juce::StringArray{"Letters", "Do Re Mi", "Numbers"}, 0));
 
     return {params.begin(), params.end()};
 }
@@ -46,6 +50,8 @@ bool NoteNamesPlugin::noteNameGet(int index, clap_note_name *noteName) noexcept
         const auto &note = noteMap[(size_t)index];
         strcpy(noteName->name, note.name.getCharPointer());
         noteName->key = (int16_t)note.key;
+        noteName->channel = 1;
+        noteName->port = -1;
         return true;
     }
 

--- a/examples/NoteNamesPlugin/NoteNamesPlugin.h
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <juce_audio_utils/juce_audio_utils.h>
+JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE("-Wunused-parameter")
+#include <clap-juce-extensions/clap-juce-extensions.h>
+JUCE_END_IGNORE_WARNINGS_GCC_LIKE
+
+class NoteNamesPlugin : public juce::AudioProcessor,
+                        public clap_juce_extensions::clap_juce_audio_processor_capabilities
+{
+  public:
+    NoteNamesPlugin();
+
+    static juce::AudioProcessorValueTreeState::ParameterLayout createParameters();
+
+    bool supportsNoteName() const noexcept override { return true; }
+    int noteNameCount() noexcept override;
+    bool noteNameGet(int index, clap_note_name *noteName) noexcept override;
+
+    const juce::String getName() const override { return JucePlugin_Name; }
+    bool acceptsMidi() const override { return true; }
+    bool producesMidi() const override { return false; }
+    bool isMidiEffect() const override { return false; }
+
+    double getTailLengthSeconds() const override { return 0.0; }
+
+    int getNumPrograms() override { return 1; }
+    int getCurrentProgram() override { return 0; }
+    void setCurrentProgram(int) override {}
+    const juce::String getProgramName(int) override { return juce::String(); }
+    void changeProgramName(int, const juce::String &) override {}
+
+    bool isBusesLayoutSupported(const juce::AudioProcessor::BusesLayout &layouts) const override;
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override {}
+    void processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) override;
+    void processBlock(juce::AudioBuffer<double> &, juce::MidiBuffer &) override {}
+
+    bool hasEditor() const override { return true; }
+    juce::AudioProcessorEditor *createEditor() override;
+
+    void getStateInformation(juce::MemoryBlock &data) override;
+    void setStateInformation(const void *data, int sizeInBytes) override;
+
+  private:
+    juce::AudioProcessorValueTreeState vts;
+    juce::ParameterAttachment noteNamesParamAttachment;
+    std::atomic<float> *noteNamesParam = nullptr;
+
+    struct NoteName
+    {
+        int key = -1;
+        juce::String name{};
+    };
+
+    using NoteNameMap = std::vector<NoteName>;
+
+    static constexpr size_t numNoteMaps = 3;
+    std::array<NoteNameMap, numNoteMaps> noteMaps;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(NoteNamesPlugin)
+};

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -201,9 +201,25 @@ struct clap_juce_audio_processor_capabilities
 
     virtual bool prefersNoteDialectClap(bool isInput) { return supportsNoteDialectClap(isInput); }
 
+    /** If your plugin supports custom note names, then override this method to return true. */
     virtual bool supportsNoteName() const noexcept { return false; }
+
+    /**
+     * If your plugin supports custom note names, then this method should be overriden
+     * to return how the number of note names taht your plugin has.
+     */
     virtual int noteNameCount() noexcept { return 0; }
-    virtual bool noteNameGet(int /*index*/, clap_note_name * /*noteName*/) noexcept { return false; }
+
+    /**
+     * The host will call this method to retrieve the note name for a given index
+     * in the range [0, noteNameCount()).
+     */
+    virtual bool noteNameGet(int /*index*/, clap_note_name * /*noteName*/) noexcept
+    {
+        return false;
+    }
+
+    /** Plugins should call this method when their note names have changed. */
     void noteNamesChanged() { noteNamesChangedSignal(); }
 
     /*

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -201,6 +201,11 @@ struct clap_juce_audio_processor_capabilities
 
     virtual bool prefersNoteDialectClap(bool isInput) { return supportsNoteDialectClap(isInput); }
 
+    virtual bool supportsNoteName() const noexcept { return false; }
+    virtual int noteNameCount() noexcept { return 0; }
+    virtual bool noteNameGet(int /*index*/, clap_note_name * /*noteName*/) noexcept { return false; }
+    void noteNamesChanged() { noteNamesChangedSignal(); }
+
     /*
      * If you are working with a host that chooses to not implement cookies you will
      * need to look up parameters by param_id. Use this method to do so.
@@ -216,6 +221,7 @@ struct clap_juce_audio_processor_capabilities
     friend class ::ClapJuceWrapper;
     std::function<void(const clap_event_param_value *)> parameterChangeHandler = nullptr;
     std::function<JUCEParameterVariant *(clap_id)> lookupParamByID = nullptr;
+    std::function<void()> noteNamesChangedSignal = nullptr;
 };
 
 /*

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -180,6 +180,15 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             processorAsClapExtensions->lookupParamByID = [this](clap_id param_id) {
                 return findVariantByParamId(param_id);
             };
+            processorAsClapExtensions->noteNamesChangedSignal = [this]() {
+                runOnMainThread([this] {
+                    if (isBeingDestroyed())
+                        return;
+
+                    if (_host.canUseNoteName())
+                        _host.noteNameChanged();
+                });
+            };
         };
 
         const bool forceLegacyParamIDs = false;
@@ -749,6 +758,27 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         if (processorAsClapExtensions)
             return processorAsClapExtensions->voiceInfoGet(info);
         return Plugin::voiceInfoGet(info);
+    }
+
+    bool implementsNoteName() const noexcept override
+    {
+        if (processorAsClapExtensions)
+            return processorAsClapExtensions->supportsNoteName();
+        return false;
+    }
+
+    int noteNameCount() noexcept override
+    {
+        if (processorAsClapExtensions)
+            return processorAsClapExtensions->noteNameCount();
+        return 0;
+    }
+
+    bool noteNameGet(int index, clap_note_name *noteName) noexcept override
+    {
+        if (processorAsClapExtensions)
+            return processorAsClapExtensions->noteNameGet (index, noteName);
+        return false;
     }
 
   public:


### PR DESCRIPTION
At the moment this feature is a little bit hard to test (see [this issue](https://github.com/free-audio/interop-tracker/issues/46)), but I think this PR implements everything we should need to get the feature working.

At the moment, the way I've done this is to just pipe through all the methods from the CLAP extension API, but I wonder if we  might want to do some intermediate work to try to make things a bit more JUCE-like for the folks using this code?