### PR TITLE
Add CLAP_PARAM_RESCAN_INFO to parameterInfoChanged callback (#113)

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -327,7 +327,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                     return;
 
                 if (_host.canUseParams())
-                    _host.paramsRescan(CLAP_PARAM_RESCAN_VALUES | CLAP_PARAM_RESCAN_TEXT);
+                    _host.paramsRescan(CLAP_PARAM_RESCAN_VALUES | CLAP_PARAM_RESCAN_TEXT |
+                                       CLAP_PARAM_RESCAN_INFO);
             });
         }
     }


### PR DESCRIPTION
Fixes #113. Confirmed that without this change parameter name rescanning doesn't work properly in Reaper (and probably other hosts too)