### PR TITLE
Add checks for user-facing function-pointers

### DIFF
--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -221,7 +221,11 @@ struct clap_juce_audio_processor_capabilities
     }
 
     /** Plugins should call this method when their note names have changed. */
-    void noteNamesChanged() { noteNamesChangedSignal(); }
+    void noteNamesChanged()
+    {
+        if (noteNamesChangedSignal != nullptr)
+            noteNamesChangedSignal();
+    }
 
     /** If your plugin supports remote controls, then override this method to return true. */
     virtual bool supportsRemoteControls() const noexcept { return false; }
@@ -243,10 +247,18 @@ struct clap_juce_audio_processor_capabilities
     }
 
     /** Plugins should call this method when their remote controls have changed. */
-    void remoteControlsChanged() { remoteControlsChangedSignal(); }
+    void remoteControlsChanged()
+    {
+        if (remoteControlsChangedSignal != nullptr)
+            remoteControlsChangedSignal();
+    }
 
     /** Plugins should call this method to suggest the host show a remote controls page. */
-    void suggestRemoteControlsPage(uint32_t pageID) { suggestRemoteControlsPageSignal(pageID); }
+    void suggestRemoteControlsPage(uint32_t pageID)
+    {
+        if (suggestRemoteControlsPageSignal != nullptr)
+            suggestRemoteControlsPageSignal(pageID);
+    }
 
     /*
      * If you are working with a host that chooses to not implement cookies you will


### PR DESCRIPTION
So when the plugin is a CLAP plugin, these function pointers should always be set to valid `std::function`s. But then the user has to check if they're in a CLAP plugin before calling them. Now the user can just call these methods fearlessly, and if the plugin is actually a VST3, Standalone, etc, then the function will just be a no-op.