### PR TITLE
Cleaning up NoteNamesPlugin example, now that dynamic name updating is working

### DIFF
--- a/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
@@ -10,13 +10,15 @@ NoteNamesPlugin::NoteNamesPlugin()
           BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)),
       vts(*this, nullptr, juce::Identifier("Parameters"), createParameters()),
       noteNamesParamAttachment(*vts.getParameter(noteNamesParamTag),
-                               [this](float) { noteNamesChanged(); }),
+                               [this](float)
+                               {
+                                   // This is annoying... when a JUCE parameter attachment is triggered
+                                   // the parameter object itself is not guaranteed to have the up-to-date
+                                   // value, so we'll have to delay a few milliseconds before alerting the host.
+                                   juce::Timer::callAfterDelay (50, [this] { noteNamesChanged(); });
+                               }),
       noteNamesParam(vts.getRawParameterValue(noteNamesParamTag))
 {
-    // At the moment, this has only been tested in Bitwig, where it works with some limitations
-    // (see https://github.com/free-audio/interop-tracker/issues/46). It would probably be good
-    // to do some tests with Reaper and some other hosts as well.
-
     noteMaps[0] = {
         {60, "C"}, {62, "D"}, {64, "E"}, {65, "F"}, {67, "G"}, {69, "A"}, {71, "B"}, {72, "C"},
     };


### PR DESCRIPTION
See free-audio/interop-tracker#46.