### PR TITLE
Tweaking plugin request resizing

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1775,13 +1775,11 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         {
             if (editor != nullptr)
             {
-                auto editorBounds = getSizeToContainChild();
-                auto b =
-                    convertToHostBounds({0, 0, editorBounds.getWidth(), editorBounds.getHeight()});
-
+                auto editorBounds = getSizeToContainChild().withPosition(0, 0);
                 {
                     const juce::ScopedValueSetter<bool> resizingParentSetter(resizingParent, true);
-                    host.guiRequestResize((uint32_t)b.getWidth(), (uint32_t)b.getHeight());
+                    host.guiRequestResize((uint32_t)editorBounds.getWidth(),
+                                          (uint32_t)editorBounds.getHeight());
                 }
 
                 setBounds(editorBounds.withPosition(0, 0));


### PR DESCRIPTION
Looks like I was converting to the host bounds one too many times leading to some situations where the host expected a UI size double what the plugin was providing. Tested with GainPlugin, Surge, and a couple other in Bitwig and Reaper.