### PR TITLE
Making sure Projucer workflow works with Xcode 15.0

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -1,70 +1,70 @@
-#name: CI-CMake
-#
-#on:
-#  push:
-#    branches:
-#      - main
-#  pull_request:
-#    branches:
-#      - main
-#
-#  workflow_dispatch:
-#
-#jobs:
-#  build_and_test:
-#    name: Build example plugins with CMake and JUCE ${{ matrix.juce_version }} on ${{ matrix.os }}
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
-#      matrix:
-#        os: [ubuntu-latest, windows-2019, macOS-latest]
-#        juce_version: ["6.0.7", "6.1.5", "6.1.6", "7.0.0", "7.0.6"]
-#
-#    steps:
-#      - name: Install Linux Deps
-#        if: runner.os == 'Linux'
-#        run: |
-#          sudo apt-get update
-#          sudo apt install libasound2-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libfreetype6-dev libglu1-mesa-dev libjack-jackd2-dev
-#          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
-#          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
-#
-#      - name: Get latest CMake
-#        uses: lukka/get-cmake@latest
-#
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#        with:
-#          submodules: recursive
-#
-#      - name: Configure
-#        shell: bash
-#        run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCLAP_JUCE_VERSION=$JUCE_VERSION -DCLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS=ON
-#        env:
-#          JUCE_VERSION: ${{ matrix.juce_version }}
-#
-#      - name: Build
-#        shell: bash
-#        run: cmake --build build --config Release --parallel 4 --target GainPlugin_CLAP
-#
-#      - name: Set up clap-info
-#        shell: bash
-#        run: |
-#          git clone --recurse-submodules https://github.com/surge-synthesizer/clap-info
-#          cd clap-info
-#          cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
-#          cmake --build build --config Release --parallel 4
-#
-#      - name: Run clap-info (Max/Linux)
-#        if: runner.os == 'Linux' || runner.os == 'MacOS'
-#        shell: bash
-#        run: |
-#          clap-info/build/clap-info --version
-#          clap-info/build/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap
-#
-#      - name: Run clap-info (Windows)
-#        if: runner.os == 'Windows'
-#        shell: bash
-#        run: |
-#          clap-info/build/Release/clap-info --version
-#          clap-info/build/Release/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap
+name: CI-CMake
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+jobs:
+  build_and_test:
+    name: Build example plugins with CMake and JUCE ${{ matrix.juce_version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
+      matrix:
+        os: [ubuntu-latest, windows-2019, macOS-latest]
+        juce_version: ["6.0.7", "6.1.5", "6.1.6", "7.0.0", "7.0.6"]
+
+    steps:
+      - name: Install Linux Deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt install libasound2-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libfreetype6-dev libglu1-mesa-dev libjack-jackd2-dev
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+
+      - name: Get latest CMake
+        uses: lukka/get-cmake@latest
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Configure
+        shell: bash
+        run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCLAP_JUCE_VERSION=$JUCE_VERSION -DCLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS=ON
+        env:
+          JUCE_VERSION: ${{ matrix.juce_version }}
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --config Release --parallel 4 --target GainPlugin_CLAP
+
+      - name: Set up clap-info
+        shell: bash
+        run: |
+          git clone --recurse-submodules https://github.com/surge-synthesizer/clap-info
+          cd clap-info
+          cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --config Release --parallel 4
+
+      - name: Run clap-info (Max/Linux)
+        if: runner.os == 'Linux' || runner.os == 'MacOS'
+        shell: bash
+        run: |
+          clap-info/build/clap-info --version
+          clap-info/build/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap
+
+      - name: Run clap-info (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          clap-info/build/Release/clap-info --version
+          clap-info/build/Release/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -1,70 +1,70 @@
-name: CI-CMake
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-
-  workflow_dispatch:
-
-jobs:
-  build_and_test:
-    name: Build example plugins with CMake and JUCE ${{ matrix.juce_version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
-      matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest]
-        juce_version: ["6.0.7", "6.1.5", "6.1.6", "7.0.0", "7.0.6"]
-
-    steps:
-      - name: Install Linux Deps
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt install libasound2-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libfreetype6-dev libglu1-mesa-dev libjack-jackd2-dev
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
-
-      - name: Get latest CMake
-        uses: lukka/get-cmake@latest
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Configure
-        shell: bash
-        run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCLAP_JUCE_VERSION=$JUCE_VERSION -DCLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS=ON
-        env:
-          JUCE_VERSION: ${{ matrix.juce_version }}
-
-      - name: Build
-        shell: bash
-        run: cmake --build build --config Release --parallel 4 --target GainPlugin_CLAP
-
-      - name: Set up clap-info
-        shell: bash
-        run: |
-          git clone --recurse-submodules https://github.com/surge-synthesizer/clap-info
-          cd clap-info
-          cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
-          cmake --build build --config Release --parallel 4
-
-      - name: Run clap-info (Max/Linux)
-        if: runner.os == 'Linux' || runner.os == 'MacOS'
-        shell: bash
-        run: |
-          clap-info/build/clap-info --version
-          clap-info/build/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap
-
-      - name: Run clap-info (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          clap-info/build/Release/clap-info --version
-          clap-info/build/Release/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap
+#name: CI-CMake
+#
+#on:
+#  push:
+#    branches:
+#      - main
+#  pull_request:
+#    branches:
+#      - main
+#
+#  workflow_dispatch:
+#
+#jobs:
+#  build_and_test:
+#    name: Build example plugins with CMake and JUCE ${{ matrix.juce_version }} on ${{ matrix.os }}
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
+#      matrix:
+#        os: [ubuntu-latest, windows-2019, macOS-latest]
+#        juce_version: ["6.0.7", "6.1.5", "6.1.6", "7.0.0", "7.0.6"]
+#
+#    steps:
+#      - name: Install Linux Deps
+#        if: runner.os == 'Linux'
+#        run: |
+#          sudo apt-get update
+#          sudo apt install libasound2-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libfreetype6-dev libglu1-mesa-dev libjack-jackd2-dev
+#          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
+#          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+#
+#      - name: Get latest CMake
+#        uses: lukka/get-cmake@latest
+#
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#        with:
+#          submodules: recursive
+#
+#      - name: Configure
+#        shell: bash
+#        run: cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCLAP_JUCE_VERSION=$JUCE_VERSION -DCLAP_EXAMPLES_TREAT_WARNINGS_AS_ERRORS=ON
+#        env:
+#          JUCE_VERSION: ${{ matrix.juce_version }}
+#
+#      - name: Build
+#        shell: bash
+#        run: cmake --build build --config Release --parallel 4 --target GainPlugin_CLAP
+#
+#      - name: Set up clap-info
+#        shell: bash
+#        run: |
+#          git clone --recurse-submodules https://github.com/surge-synthesizer/clap-info
+#          cd clap-info
+#          cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+#          cmake --build build --config Release --parallel 4
+#
+#      - name: Run clap-info (Max/Linux)
+#        if: runner.os == 'Linux' || runner.os == 'MacOS'
+#        shell: bash
+#        run: |
+#          clap-info/build/clap-info --version
+#          clap-info/build/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap
+#
+#      - name: Run clap-info (Windows)
+#        if: runner.os == 'Windows'
+#        shell: bash
+#        run: |
+#          clap-info/build/Release/clap-info --version
+#          clap-info/build/Release/clap-info build/examples/GainPlugin/GainPlugin_artefacts/Release/CLAP/GainPlugin.clap

--- a/.github/workflows/build-projucer.yml
+++ b/.github/workflows/build-projucer.yml
@@ -26,6 +26,13 @@ jobs:
           - os: macos-latest
             jucer: build/_deps/juce-src/extras/Projucer/Builds/MacOSX/build/Debug/Projucer.app/Contents/MacOS/Projucer
             clap_gen: "Xcode"
+            xcode_version: latest-stable
+            juce_version: "7.0.6"
+            cxx_standard: 17
+          - os: macos-latest
+            jucer: build/_deps/juce-src/extras/Projucer/Builds/MacOSX/build/Debug/Projucer.app/Contents/MacOS/Projucer
+            clap_gen: "Xcode"
+            xcode_version: "15.0"
             juce_version: "7.0.6"
             cxx_standard: 17
           - os: windows-2022
@@ -51,7 +58,7 @@ jobs:
         if: runner.os == 'MacOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: ${{ matrix.xcode_version }}
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-projucer.yml
+++ b/.github/workflows/build-projucer.yml
@@ -29,7 +29,7 @@ jobs:
             xcode_version: latest-stable
             juce_version: "7.0.6"
             cxx_standard: 17
-          - os: macos-latest
+          - os: macos-13
             jucer: build/_deps/juce-src/extras/Projucer/Builds/MacOSX/build/Debug/Projucer.app/Contents/MacOS/Projucer
             clap_gen: "Xcode"
             xcode_version: "15.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CMAKE_GENERATOR STREQUAL Xcode)
         message(STATUS "Enabling Xcode 15 linker workaround!")
         add_link_options("-Wl,-ld_classic")
         add_compile_definitions(JUCE_SILENCE_XCODE_15_LINKER_WARNING=1)
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment target")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment target" FORCE)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,10 @@ if(CMAKE_GENERATOR STREQUAL Xcode)
     # Funky work around for Xcode 15, see: https://forum.juce.com/t/vst-au-builds-fail-after-upgrading-to-xcode-15/57936/43
     message(STATUS "Configuring CJE with Xcode version ${XCODE_VERSION}")
     if((${XCODE_VERSION} STREQUAL "15.0") OR (${XCODE_VERSION} STREQUAL "15.0.1"))
+        message(STATUS "Enabling Xcode 15 linker workaround!")
         add_link_options("-Wl,-ld_classic")
         add_compile_definitions(JUCE_SILENCE_XCODE_15_LINKER_WARNING=1)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment target")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,15 @@ endif()
 message( STATUS "Building CLAP with CLAP_CXX_STANDARD=${CLAP_CXX_STANDARD}")
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(CMAKE_GENERATOR STREQUAL Xcode)
+    # Funky work around for Xcode 15, see: https://forum.juce.com/t/vst-au-builds-fail-after-upgrading-to-xcode-15/57936/43
+    message(STATUS "Configuring CJE with Xcode version ${XCODE_VERSION}")
+    if((${XCODE_VERSION} STREQUAL "15.0") OR (${XCODE_VERSION} STREQUAL "15.0.1"))
+        add_link_options("-Wl,-ld_classic")
+        add_compile_definitions(JUCE_SILENCE_XCODE_15_LINKER_WARNING=1)
+    endif()
+endif()
+
 option(CLAP_JUCE_EXTENSIONS_BUILD_EXAMPLES "Add targets for building and running clap-juce-extensions examples" ${is_toplevel})
 if(CLAP_JUCE_EXTENSIONS_BUILD_EXAMPLES)
     # The examples need JUCE to be imported before the CLAP helper targets


### PR DESCRIPTION
Adds a workaround for using the Projucer workflow with Xcode 15 (for more information, see [this thread](https://forum.juce.com/t/vst-au-builds-fail-after-upgrading-to-xcode-15/57936/43)). Also adds a CI job to test this workaround.