### PR TITLE
Update CLAP libs and support preset-load extension

### DIFF
--- a/cmake/ClapTargetHelpers.cmake
+++ b/cmake/ClapTargetHelpers.cmake
@@ -133,7 +133,7 @@ function(clap_juce_extensions_plugin_internal)
                 )
     endif()
 
-    target_compile_definitions(${claptarget} PRIVATE
+    target_compile_definitions(${target} PUBLIC
             CLAP_ID="${CJA_CLAP_ID}"
             CLAP_FEATURES=${CJA_CLAP_FEATURES_PARSED}
             CLAP_MANUAL_URL="${CJA_CLAP_MANUAL_URL}"

--- a/cmake/ClapTargetHelpers.cmake
+++ b/cmake/ClapTargetHelpers.cmake
@@ -133,7 +133,7 @@ function(clap_juce_extensions_plugin_internal)
                 )
     endif()
 
-    target_compile_definitions(${target} PUBLIC
+    target_compile_definitions(${claptarget} PRIVATE
             CLAP_ID="${CJA_CLAP_ID}"
             CLAP_FEATURES=${CJA_CLAP_FEATURES_PARSED}
             CLAP_MANUAL_URL="${CJA_CLAP_MANUAL_URL}"

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -216,13 +216,13 @@ struct clap_juce_audio_processor_capabilities
      * If your plugin supports custom note names, then this method should be overriden
      * to return how the number of note names that your plugin has.
      */
-    virtual int noteNameCount() noexcept { return 0; }
+    virtual uint32_t noteNameCount() noexcept { return 0; }
 
     /**
      * The host will call this method to retrieve the note name for a given index
      * in the range [0, noteNameCount()).
      */
-    virtual bool noteNameGet(int /*index*/, clap_note_name * /*noteName*/) noexcept
+    virtual bool noteNameGet(uint32_t /*index*/, clap_note_name * /*noteName*/) noexcept
     {
         return false;
     }

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -24,7 +24,6 @@ const clap_plugin *clap_create_plugin(const struct clap_plugin_factory *, const 
                                       const char *);
 }
 
-
 /** Forward declarations for any JUCE classes we might need. */
 namespace juce
 {
@@ -284,8 +283,8 @@ struct clap_juce_audio_processor_capabilities
      * The plugin should call this from within presetLoadFromLocation() to report an error when
      * trying to load the preset, and then return false from presetLoadFromLocation().
      */
-    void reportPresetLoadError(uint32_t location_kind, const char * location, const char * load_key,
-                               int32_t os_error, const juce::String & message)
+    void reportPresetLoadError(uint32_t location_kind, const char *location, const char *load_key,
+                               int32_t os_error, const juce::String &message)
     {
         if (onPresetLoadError != nullptr)
             onPresetLoadError(location_kind, location, load_key, os_error, message);
@@ -319,8 +318,8 @@ struct clap_juce_audio_processor_capabilities
     std::function<void()> remoteControlsChangedSignal = nullptr;
     std::function<void(uint32_t)> suggestRemoteControlsPageSignal = nullptr;
     std::function<void(uint32_t location_kind, const char *location, const char *load_key,
-                   int32_t os_error, const juce::String &msg)>
-    onPresetLoadError = nullptr;
+                       int32_t os_error, const juce::String &msg)>
+        onPresetLoadError = nullptr;
     std::function<const void *(const char *)> extensionGet = nullptr;
 
     friend const clap_plugin *ClapAdapter::clap_create_plugin(const struct clap_plugin_factory *,

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -274,7 +274,7 @@ struct clap_juce_audio_processor_capabilities
      * The plugin should override this method to attempt to load a preset from a location,
      * and return true if the load occurred successfully.
      */
-    virtual bool presetLoadFromLocation(uint32_t location_kind, const char * /*location*/,
+    virtual bool presetLoadFromLocation(uint32_t /*location_kind*/, const char * /*location*/,
                                         const char * /*load_key*/) noexcept
     {
         return false;

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -274,21 +274,21 @@ struct clap_juce_audio_processor_capabilities
      * The plugin should override this method to attempt to load a preset from a location,
      * and return true if the load occurred successfully.
      */
-    virtual bool presetLoadFromLocation(uint32_t location_kind, const char *location,
-                                        const char *load_key) noexcept
+    virtual bool presetLoadFromLocation(uint32_t location_kind, const char * /*location*/,
+                                        const char * /*load_key*/) noexcept
     {
         return false;
     }
 
     /**
-     * The plugin should call this from within presetLoadFromLocation() to report an error when trying
-     * to load the preset, and then return false from presetLoadFromLocation().
+     * The plugin should call this from within presetLoadFromLocation() to report an error when
+     * trying to load the preset, and then return false from presetLoadFromLocation().
      */
-    void reportPresetLoadError(uint32_t location_kind, const char *location, const char *load_key,
-                               int32_t os_error, const juce::String &message)
+    void reportPresetLoadError(uint32_t location_kind, const char * location, const char * load_key,
+                               int32_t os_error, const juce::String & message)
     {
         if (onPresetLoadError != nullptr)
-            onPresetLoadError (location_kind, location, load_key, os_error, message);
+            onPresetLoadError(location_kind, location, load_key, os_error, message);
     }
 
     /*

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -291,8 +291,6 @@ struct clap_juce_audio_processor_capabilities
             onPresetLoadError (location_kind, location, load_key, os_error, message);
     }
 
-    // @TODO (jatin): callbacks for preset load error and success
-
     /*
      * If you are working with a host that chooses to not implement cookies you will
      * need to look up parameters by param_id. Use this method to do so.

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -68,7 +68,7 @@ JUCE_END_IGNORE_WARNINGS_GCC_LIKE
     }
 
 #if CLAP_SUPPORTS_CUSTOM_FACTORY
-extern void *clapJuceExtensionCustomFactory(const char *);
+extern const void *clapJuceExtensionCustomFactory(const char *);
 #endif
 
 #if !JUCE_MAC

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -173,7 +173,7 @@ class EditorContextMenu : public juce::HostProvidedContextMenu
 
     juce::PopupMenu getEquivalentPopupMenu() const override
     {
-        host.contextMenuPopulate(host.host(), &menuTarget, builder.builder());
+        host.contextMenuPopulate(&menuTarget, builder.builder());
 
         jassert(builder.menuStack.size() == 1); // one of the sub-menus has not been closed?
         return builder.menuStack.front();
@@ -181,11 +181,11 @@ class EditorContextMenu : public juce::HostProvidedContextMenu
 
     void showNativeMenu(Point<int> pos) const override
     {
-        if (!host.contextMenuCanPopup(host.host()))
+        if (!host.contextMenuCanPopup())
             return;
 
         // TODO: figure out screen index?
-        host.contextMenuPopup(host.host(), &menuTarget, 0, pos.x, pos.y);
+        host.contextMenuPopup(&menuTarget, 0, pos.x, pos.y);
     }
 
     clap_context_menu_target menuTarget{};
@@ -231,7 +231,7 @@ class EditorContextMenu : public juce::HostProvidedContextMenu
                 item.isEnabled = entry->is_enabled;
                 item.action = [&host = this->host, target = *this->menuTarget,
                                id = entry->action_id] {
-                    host.contextMenuPerform(host.host(), &target, id);
+                    host.contextMenuPerform(&target, id);
                 };
 
                 currentMenu.addItem(item);
@@ -247,7 +247,7 @@ class EditorContextMenu : public juce::HostProvidedContextMenu
                 item.isTicked = entry->is_checked;
                 item.action = [&host = this->host, target = *this->menuTarget,
                                id = entry->action_id] {
-                    host.contextMenuPerform(host.host(), &target, id);
+                    host.contextMenuPerform(&target, id);
                 };
 
                 currentMenu.addItem(item);
@@ -1025,14 +1025,14 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         return false;
     }
 
-    int noteNameCount() noexcept override
+    uint32_t noteNameCount() noexcept override
     {
         if (processorAsClapExtensions)
             return processorAsClapExtensions->noteNameCount();
         return 0;
     }
 
-    bool noteNameGet(int index, clap_note_name *noteName) noexcept override
+    bool noteNameGet(uint32_t index, clap_note_name *noteName) noexcept override
     {
         if (processorAsClapExtensions)
             return processorAsClapExtensions->noteNameGet(index, noteName);

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -68,7 +68,7 @@ JUCE_END_IGNORE_WARNINGS_GCC_LIKE
     }
 
 #if CLAP_SUPPORTS_CUSTOM_FACTORY
-extern const void * JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *);
+extern const void *JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *);
 #endif
 
 #if !JUCE_MAC
@@ -230,9 +230,7 @@ class EditorContextMenu : public juce::HostProvidedContextMenu
                 item.text = juce::CharPointer_UTF8(entry->label);
                 item.isEnabled = entry->is_enabled;
                 item.action = [&host = this->host, target = *this->menuTarget,
-                               id = entry->action_id] {
-                    host.contextMenuPerform(&target, id);
-                };
+                               id = entry->action_id] { host.contextMenuPerform(&target, id); };
 
                 currentMenu.addItem(item);
             }
@@ -246,9 +244,7 @@ class EditorContextMenu : public juce::HostProvidedContextMenu
                 item.isEnabled = entry->is_enabled;
                 item.isTicked = entry->is_checked;
                 item.action = [&host = this->host, target = *this->menuTarget,
-                               id = entry->action_id] {
-                    host.contextMenuPerform(&target, id);
-                };
+                               id = entry->action_id] { host.contextMenuPerform(&target, id); };
 
                 currentMenu.addItem(item);
             }

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -437,8 +437,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             processorAsClapExtensions->onPresetLoadError =
                 [this](uint32_t location_kind, const char *location, const char *load_key,
                        int32_t os_error, const juce::String &msg) {
-                    _host.presetLoadOnError(location_kind, location, load_key, os_error,
-                                            msg.toRawUTF8());
+                    if (_host.canUsePresetLoad())
+                        _host.presetLoadOnError(location_kind, location, load_key, os_error,
+                                                msg.toRawUTF8());
                 };
             processorAsClapExtensions->extensionGet = [this](const char *name) {
                 return _host.host()->get_extension(_host.host(), name);
@@ -1101,7 +1102,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             if (processorAsClapExtensions->presetLoadFromLocation(location_kind, location,
                                                                   load_key))
             {
-                _host.presetLoadLoaded(location_kind, location, load_key);
+                if (_host.canUsePresetLoad())
+                    _host.presetLoadLoaded(location_kind, location, load_key);
                 return true;
             }
         }

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -41,6 +41,11 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC(4100 4127 4244)
 #include <clap/helpers/host-proxy.hxx>
 #include <clap/helpers/plugin.hh>
 #include <clap/helpers/plugin.hxx>
+
+#if CLAP_VERSION_LT(1,2,0)
+static_assert(false, "CLAP juce wrapper requires at least clap 1.2.0");
+#endif
+
 JUCE_END_IGNORE_WARNINGS_MSVC
 JUCE_END_IGNORE_WARNINGS_GCC_LIKE
 

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -68,7 +68,7 @@ JUCE_END_IGNORE_WARNINGS_GCC_LIKE
     }
 
 #if CLAP_SUPPORTS_CUSTOM_FACTORY
-extern const void *clapJuceExtensionCustomFactory(const char *);
+extern const void * JUCE_CALLTYPE clapJuceExtensionCustomFactory(const char *);
 #endif
 
 #if !JUCE_MAC


### PR DESCRIPTION
The main idea here is to support the `preset-load` extension. However, to do that properly, I had to update clap-helpers (see https://github.com/free-audio/clap-helpers/pull/19). I ended up just pulling both the clap-helpers and clap submodules up to their HEADs. If folks aren't comfortable with that, I'd be happy to back out to an earlier version, so long as it contains the relevant changes.

~~I also made a tweak to the CMake so that various global CLAP definitions (e.g. `CLAP_ID`, `CLAP_FEATURES`, etc) are exposed to the plugin code, since I found `CLAP_ID` to be useful in my own implementation of `preset-load`. Again, we might not want to make _all_ of these definitions public, so that's maybe something we should talk about.~~

The `preset-load` changes themselves are pretty straightforward, and follow the pattern that we've used for the other CLAP "extended" capabilities. BYOD has supported `preset-load` using this branch since version 1.2.0, so that might be a [useful example](https://github.com/Chowdhury-DSP/BYOD/blob/main/src/state/presets/PresetDiscovery.cpp#L206) for folks.