### PR TITLE
Change XCODE_WARNING from =TRUE to =1

### DIFF
--- a/cmake/ClapTargetHelpers.cmake
+++ b/cmake/ClapTargetHelpers.cmake
@@ -119,7 +119,7 @@ function(clap_juce_extensions_plugin_internal)
         # see: https://forum.juce.com/t/vst-au-builds-fail-after-upgrading-to-xcode-15/57936/43
         if( ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "15.0.0" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "15.1")
             target_link_options(${claptarget} PUBLIC "-Wl,-ld_classic")
-            target_compile_definitions(${claptarget} PUBLIC JUCE_SILENCE_XCODE_15_LINKER_WARNING=TRUE)
+            target_compile_definitions(${claptarget} PUBLIC JUCE_SILENCE_XCODE_15_LINKER_WARNING=1)
             if (${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_LESS "10.13")
                message(STATUS "Changing OSX Deployment Target from ${CMAKE_OSX_DEPLOYMENT_TARGET} to 10.13 for XCode 15")
                set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment target" FORCE)


### PR DESCRIPTION
We defined the XCODE_WARNING flag =TRUE but juce defines it =1 in its headers and so with -Werror on macos you would get a -Wmacro-redefined with JUCE 7. Fix by changing =TRUE to =1