### PR TITLE
Supporting JUCE-level track info

### DIFF
--- a/examples/GainPlugin/GainPlugin.cpp
+++ b/examples/GainPlugin/GainPlugin.cpp
@@ -85,6 +85,13 @@ void GainPlugin::setStateInformation(const void *data, int sizeInBytes)
             vts.replaceState(juce::ValueTree::fromXml(*xmlState));
 }
 
+void GainPlugin::updateTrackProperties(const TrackProperties &properties)
+{
+    trackProperties = properties;
+    if (updateEditor)
+        updateEditor();
+}
+
 void GainPlugin::paramIndicationSetMapping(const juce::RangedAudioParameter &param,
                                            bool has_mapping, const juce::Colour *colour,
                                            const juce::String &label,

--- a/examples/GainPlugin/GainPlugin.h
+++ b/examples/GainPlugin/GainPlugin.h
@@ -39,6 +39,8 @@ class GainPlugin : public juce::AudioProcessor,
     void getStateInformation(juce::MemoryBlock &data) override;
     void setStateInformation(const void *data, int sizeInBytes) override;
 
+    void updateTrackProperties(const TrackProperties &properties) override;
+
     bool supportsParamIndication() const noexcept override { return true; }
     void paramIndicationSetMapping(const juce::RangedAudioParameter &param, bool has_mapping,
                                    const juce::Colour *colour, const juce::String &label,
@@ -51,6 +53,9 @@ class GainPlugin : public juce::AudioProcessor,
     juce::String getPluginTypeString() const;
     auto *getGainParameter() { return gainDBParameter; }
     auto &getValueTreeState() { return vts; }
+    const auto& getTrackProperties() const { return trackProperties; }
+
+    std::function<void()> updateEditor = nullptr;
 
   private:
     ModulatableFloatParameter *gainDBParameter = nullptr;
@@ -58,6 +63,8 @@ class GainPlugin : public juce::AudioProcessor,
     juce::AudioProcessorValueTreeState vts;
 
     juce::dsp::Gain<float> gain;
+
+    TrackProperties trackProperties{};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GainPlugin)
 };

--- a/examples/GainPlugin/PluginEditor.cpp
+++ b/examples/GainPlugin/PluginEditor.cpp
@@ -62,6 +62,12 @@ PluginEditor::PluginEditor(GainPlugin &plug) : juce::AudioProcessorEditor(plug),
     constrainer.setSizeLimits (200, 200, 500, 500);
     constrainer.setFixedAspectRatio (1.0);
     setConstrainer (&constrainer);
+
+    plugin.updateEditor = [this] {
+        gainSlider->setColour (juce::Slider::rotarySliderFillColourId, plugin.getTrackProperties().colour);
+        repaint();
+    };
+    plugin.updateEditor();
 }
 
 PluginEditor::~PluginEditor()
@@ -69,6 +75,7 @@ PluginEditor::~PluginEditor()
     auto *gainParameter = plugin.getGainParameter();
     plugin.getValueTreeState().removeParameterListener(gainParameter->paramID, this);
     plugin.paramIndicationHelper.removeListener(this);
+    plugin.updateEditor = nullptr;
 }
 
 void PluginEditor::resized()
@@ -83,7 +90,7 @@ void PluginEditor::paint(juce::Graphics &g)
     g.setColour(juce::Colours::black);
     g.setFont(25.0f);
     const auto titleBounds = getLocalBounds().removeFromTop(30);
-    const auto titleText = "Gain Plugin " + plugin.getPluginTypeString();
+    const auto titleText = "Gain Plugin " + plugin.getPluginTypeString() + " (" + plugin.getTrackProperties().name + ")";
     g.drawFittedText(titleText, titleBounds, juce::Justification::centred, 1);
 
     if (auto *paramIndicatorInfo =

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1051,6 +1051,28 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         return false;
     }
 
+    bool implementsTrackInfo() const noexcept override { return true; }
+
+    void trackInfoChanged() noexcept override
+    {
+        clap_track_info clapTrackInfo {};
+        if (_host.trackInfoGet(&clapTrackInfo))
+        {
+            juce::AudioProcessor::TrackProperties juceTrackInfo{};
+
+            if (clapTrackInfo.flags & CLAP_TRACK_INFO_HAS_TRACK_NAME)
+            {
+                juceTrackInfo.name = juce::CharPointer_UTF8(clapTrackInfo.name);
+            }
+            if (clapTrackInfo.flags & CLAP_TRACK_INFO_HAS_TRACK_COLOR)
+            {
+                juceTrackInfo.colour = clapColourToJUCEColour(clapTrackInfo.color);
+            }
+
+            processor->updateTrackProperties(juceTrackInfo);
+        }
+    }
+
     bool implementsParamIndication() const noexcept override
     {
         if (processorAsClapExtensions)


### PR DESCRIPTION
Adding support for the `track-info` extension. The track info extension allows the host to provide more than what JUCE's [`TrackProperties`](https://docs.juce.com/master/structAudioProcessor_1_1TrackProperties.html) supports, but for now I'm just passing through the JUCE-level information.

https://github.com/free-audio/clap-juce-extensions/assets/13724188/33c98906-063b-43cb-995f-f0fa9c3e6252

