### PR TITLE
Fix erroneous test for XCode 15.1

### DIFF
--- a/cmake/ClapTargetHelpers.cmake
+++ b/cmake/ClapTargetHelpers.cmake
@@ -117,7 +117,7 @@ function(clap_juce_extensions_plugin_internal)
 
         # Address the xcode linker juce issue
         # see: https://forum.juce.com/t/vst-au-builds-fail-after-upgrading-to-xcode-15/57936/43
-        if( ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "15.0.0" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "15.1")
+        if( ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "15.0.0" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "15.0.0.15000100")
             target_link_options(${claptarget} PUBLIC "-Wl,-ld_classic")
             target_compile_definitions(${claptarget} PUBLIC JUCE_SILENCE_XCODE_15_LINKER_WARNING=1)
             if (${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_LESS "10.13")


### PR DESCRIPTION
With Xcode 15.3 installed:
```
/usr/bin/c++ --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
```
CMake reports:
```
-- The C compiler identification is AppleClang 15.0.0.15000309
-- The CXX compiler identification is AppleClang 15.0.0.15000309
```

Hence this test does not work as intended:
`if( ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "15.0.0" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "15.1")`

To confirm my suspicions about how the version number is reported by Apple Clang I booted into an old install running Xcode 14.2:

```
/usr/bin/c++ --version
Apple clang version 14.0.0 (clang-1400.0.29.202)
```
which CMake reports as:
```
-- The C compiler identification is AppleClang 14.0.0.14000029
-- The CXX compiler identification is AppleClang 14.0.0.14000029
```

so the real version number of Clang is in the 4th part, and takes the format for 2 digits for each part, dropping the final part from the longer number reported from `--version`.

I think this revised test is OK, although I was unable to test against a relevant version of Xcode that needs the linker flags and change of deployment target.