### PR TITLE
STEPPED parameters mis-handled

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1262,8 +1262,13 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         if (paramVariant.processorParam->isAutomatable())
             info->flags = info->flags | CLAP_PARAM_IS_AUTOMATABLE;
 
-        if (paramVariant.processorParam->isBoolean() || paramVariant.processorParam->isDiscrete())
+        if (paramVariant.processorParam->isBoolean())
         {
+            // This condition used to say || paramVariant.processorParam->isDiscrete())
+            // but AudioProcessorChoice and Int normalize to 0...1 in
+            // JUCE so this ends up breaking the built in controls
+            // at the edge in CLAP vs VST3
+
             info->flags = info->flags | CLAP_PARAM_IS_STEPPED;
         }
 


### PR DESCRIPTION
AudioParameterInt and CHoice use 0...1 normalizationfor their lists. This makes them error prone under range changes, which is an overall JUCE problem, but also means if we indicate them as STEPPED in clap you can only select the extream in the bitwig params view and so on. So for now stay with JUCE and make these discrete types not stepped.