### PR TITLE
Support double precision processing

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1583,7 +1583,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             {
                 for (uint32_t ch = 0; ch < process->audio_inputs[idx].channel_count; ++ch)
                 {
-                    if (supportsDouble && process->audio_outputs[idx].data64 != nullptr)
+                    if (supportsDouble && process->audio_inputs[idx].data64 != nullptr)
                     {
                         auto *ic = process->audio_inputs[idx].data64[ch] + n;
                         if (inputChannels < outputChannels)


### PR DESCRIPTION
If `supprotsDoublePrecision` in the processor is true, advertise FLOAT64 audio ports and adjust the processing loop.

Tested by running Airwindows Consolidated as CLAP in reaper (which supports double) and Bitwig (which does not) and seeing appropriate behavior.