### PR TITLE
Add detail to git install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ somewhere in your dev environment, setting a few CMake variables, and adding a c
 The instructions are as follows:
 
 1. Add `https://github.com/free-audio/clap-juce-extensions.git` as a submodule of your project, or otherwise make the
-   source available to your cmake (CPM, side by side check out in CI, etc...).
+   source available to your cmake (CPM, side by side check out in CI, etc...). For example:
+
+```git
+git submodule add -b main https://github.com/free-audio/clap-juce-extensions.git libs/clap-juce-extensions
+git submodule update --init --recursive # important, this will grab clap and clap-helpers
+```
+   
 2. Load the `clap-juce-extension` in your CMake after you have loaded JUCE. For instance, you could do
 
 ```cmake


### PR DESCRIPTION
When setting up I didn't realize I needed to recursively init the submodule.

Not doing so results in an error like so: 

```
CMake Error at modules/clap-juce-extensions/CMakeLists.txt:48 (add_subdirectory):
  The source directory

    /Users/sudara/projects/Meter/modules/clap-juce-extensions/clap-libs/clap

  does not contain a CMakeLists.txt file.
```

I figured adding that detail might help someone else.

Yay clap!