### PR TITLE
Set the loop points in juce::AudioPlayHead::PositionInfo

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -788,6 +788,11 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                                        CLAP_BEATTIME_FACTOR);
                 posinfo.setPpqPositionOfLastBarStart(1.0 * (double)transportInfo->bar_start /
                                                      CLAP_BEATTIME_FACTOR);
+                juce::AudioPlayHead::LoopPoints loopPoints {
+                    1.0 * (double) transportInfo->loop_start_beats / CLAP_BEATTIME_FACTOR,
+                    1.0 * (double) transportInfo->loop_end_beats / CLAP_BEATTIME_FACTOR
+                };
+                posinfo.setLoopPoints(loopPoints);
             }
             if (flags & CLAP_TRANSPORT_HAS_SECONDS_TIMELINE)
             {


### PR DESCRIPTION
The wrapper wasn't setting the loop `ppqStart` and `ppqEnd` of `juce::AudioPlayHead::PositionInfo::LoopPoints` that can be accessed via `getPlayHead()->getPosition()->getLoopPoints()`, this proved to be an issue in one of my plugins.

There maybe an argument that within this code (that immediately follows my addition):
```
if (flags & CLAP_TRANSPORT_HAS_SECONDS_TIMELINE)
{
    auto timeInSeconds =
        1.0 * (double)transportInfo->song_pos_seconds / CLAP_SECTIME_FACTOR;
    posinfo.setTimeInSeconds(timeInSeconds);
    posinfo.setTimeInSamples((int64_t)(timeInSeconds * sampleRate()));
}
```
perhaps could try and set these loop point by converting seconds to PPQ *iff* they hadn't already been set by the preceding code, but I think it's a very tenuous argument and it's likely an extremely niche edge case scenario that wouldn't be able to set the loop points by beats anyway and not worth covering.

Proposed change fixes my issue.