### PR TITLE
Call juce::PopupMenu::dismissAllActiveMenus in guiDestroy

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -2076,7 +2076,11 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
 
     void guiDestroy() noexcept override
     {
-        editorWrapper.reset(nullptr);
+        if (editorWrapper)
+        {
+            juce::PopupMenu::dismissAllActiveMenus();
+            editorWrapper.reset(nullptr);
+        }
         guiParentAttached = false;
     }
 


### PR DESCRIPTION
Recent version of JUCE do this in the VST2/3/AAX/AU wrappers so symmetrize with the call here. This went un-noticed in surge since we call it in the destructor of Surge GUI ourselves, from before the juce call was there.