### PR TITLE
Support JUCE-style note names for JUCE 8.0.5 and above

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest] # win 2019 needed for juce 6
-        juce_version: ["6.0.7", "6.1.5", "6.1.6", "7.0.0", "7.0.6", "7.0.12","8.0.4"]
+        juce_version: ["6.0.7", "6.1.5", "6.1.6", "7.0.0", "7.0.6", "7.0.12","8.0.6"]
 
 
     steps:

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest] # win 2019 needed for juce 6
+        os: [ubuntu-22.04, windows-2019, macOS-latest] # win 2019 needed for juce 6
         juce_version: ["6.0.7", "6.1.5", "6.1.6", "7.0.0", "7.0.6", "7.0.12","8.0.6"]
 
 

--- a/.github/workflows/build-projucer.yml
+++ b/.github/workflows/build-projucer.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             jucer: build/_deps/juce-src/extras/Projucer/Builds/LinuxMakefile/build/Projucer
             clap_gen: "Unix Makefiles"
             juce_version: "7.0.6"

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ cmake-stamp
 *.txt.user
 *.txt.user.*
 
+# Projucer
+JuceLibraryCode/
+
 # CMake
 build/
 build32/

--- a/examples/GainPlugin/CMakeLists.txt
+++ b/examples/GainPlugin/CMakeLists.txt
@@ -52,7 +52,7 @@ target_compile_definitions(GainPlugin PUBLIC
     JUCE_REPORT_APP_USAGE=0
     JUCE_WEB_BROWSER=0
     JUCE_USE_CURL=0
-    JUCE_JACK=1
+    JUCE_JACK=0
     JUCE_ALSA=1
     JUCE_MODAL_LOOPS_PERMITTED=1 # required for Linux FileChooser with JUCE 6.0.7
     JUCE_VST3_CAN_REPLACE_VST2=0

--- a/examples/GainPlugin/PluginEditor.cpp
+++ b/examples/GainPlugin/PluginEditor.cpp
@@ -64,7 +64,13 @@ PluginEditor::PluginEditor(GainPlugin &plug) : juce::AudioProcessorEditor(plug),
     setConstrainer (&constrainer);
 
     plugin.updateEditor = [this] {
+#if JUCE_VERSION >= 0x080005
+        const auto newColour = plugin.getTrackProperties().colour;
+        if (newColour.has_value())
+            gainSlider->setColour (juce::Slider::rotarySliderFillColourId, *newColour);
+#else
         gainSlider->setColour (juce::Slider::rotarySliderFillColourId, plugin.getTrackProperties().colour);
+#endif
         repaint();
     };
     plugin.updateEditor();
@@ -87,10 +93,14 @@ void PluginEditor::paint(juce::Graphics &g)
 {
     g.fillAll(juce::Colours::grey);
 
+    auto titleText = "Gain Plugin " + plugin.getPluginTypeString();
+    const auto trackName = plugin.getTrackProperties().name;
+    if (trackName.has_value())
+        titleText += " (" + *trackName + ")";
+
     g.setColour(juce::Colours::black);
     g.setFont(25.0f);
     const auto titleBounds = getLocalBounds().removeFromTop(30);
-    const auto titleText = "Gain Plugin " + plugin.getPluginTypeString() + " (" + plugin.getTrackProperties().name + ")";
     g.drawFittedText(titleText, titleBounds, juce::Justification::centred, 1);
 
     if (auto *paramIndicatorInfo =

--- a/examples/GainPlugin/PluginEditor.cpp
+++ b/examples/GainPlugin/PluginEditor.cpp
@@ -95,8 +95,12 @@ void PluginEditor::paint(juce::Graphics &g)
 
     auto titleText = "Gain Plugin " + plugin.getPluginTypeString();
     const auto trackName = plugin.getTrackProperties().name;
+#if JUCE_VERSION >= 0x080005
     if (trackName.has_value())
         titleText += " (" + *trackName + ")";
+#else
+        titleText += " (" + trackName + ")";
+#endif
 
     g.setColour(juce::Colours::black);
     g.setFont(25.0f);

--- a/examples/HostSpecificExtensionsPlugin/CMakeLists.txt
+++ b/examples/HostSpecificExtensionsPlugin/CMakeLists.txt
@@ -38,7 +38,7 @@ target_compile_definitions(HostSpecificExtensionsPlugin PUBLIC
     JUCE_REPORT_APP_USAGE=0
     JUCE_WEB_BROWSER=0
     JUCE_USE_CURL=0
-    JUCE_JACK=1
+    JUCE_JACK=0
     JUCE_ALSA=1
     JUCE_MODAL_LOOPS_PERMITTED=1 # required for Linux FileChooser with JUCE 6.0.7
     JUCE_VST3_CAN_REPLACE_VST2=0

--- a/examples/NoteNamesPlugin/CMakeLists.txt
+++ b/examples/NoteNamesPlugin/CMakeLists.txt
@@ -26,7 +26,7 @@ target_compile_definitions(NoteNamesPlugin PUBLIC
     JUCE_REPORT_APP_USAGE=0
     JUCE_WEB_BROWSER=0
     JUCE_USE_CURL=0
-    JUCE_JACK=1
+    JUCE_JACK=0
     JUCE_ALSA=1
     JUCE_MODAL_LOOPS_PERMITTED=1 # required for Linux FileChooser with JUCE 6.0.7
     JUCE_VST3_CAN_REPLACE_VST2=0

--- a/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
@@ -41,6 +41,21 @@ juce::AudioProcessorValueTreeState::ParameterLayout NoteNamesPlugin::createParam
     return {params.begin(), params.end()};
 }
 
+#if JUCE_VERSION >= 0x080005
+std::optional<juce::String> NoteNamesPlugin::getNameForMidiNoteNumber (int noteNumber, [[maybe_unused]] int midiChannel)
+{
+    const auto noteNamesIndex = static_cast<size_t>(noteNamesParam->load());
+    const auto &noteMap = noteMaps[noteNamesIndex];
+
+    for (const auto& note : noteMap)
+    {
+        if (note.key == noteNumber)
+            return note.name;
+    }
+
+    return std::nullopt;
+}
+#else
 int NoteNamesPlugin::noteNameCount() noexcept
 {
     const auto noteNamesIndex = static_cast<size_t>(noteNamesParam->load());
@@ -63,6 +78,7 @@ bool NoteNamesPlugin::noteNameGet(int index, clap_note_name *noteName) noexcept
 
     return false;
 }
+#endif
 
 bool NoteNamesPlugin::isBusesLayoutSupported(const juce::AudioProcessor::BusesLayout &) const
 {

--- a/examples/NoteNamesPlugin/NoteNamesPlugin.h
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.h
@@ -13,9 +13,13 @@ class NoteNamesPlugin : public juce::AudioProcessor,
 
     static juce::AudioProcessorValueTreeState::ParameterLayout createParameters();
 
+#if JUCE_VERSION >= 0x080005
+    std::optional<juce::String> getNameForMidiNoteNumber (int note, int midiChannel) override;
+#else
     bool supportsNoteName() const noexcept override { return true; }
     int noteNameCount() noexcept override;
     bool noteNameGet(int index, clap_note_name *noteName) noexcept override;
+#endif
 
     const juce::String getName() const override { return JucePlugin_Name; }
     bool acceptsMidi() const override { return true; }

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -209,6 +209,9 @@ struct clap_juce_audio_processor_capabilities
 
     virtual bool prefersNoteDialectClap(bool isInput) { return supportsNoteDialectClap(isInput); }
 
+    // JUCE added support for note names in juce::AudioProcessor
+    // in version 8.0.5, so we don't need these methods anymore.
+#if JUCE_VERSION < 0x080005
     /** If your plugin supports custom note names, then override this method to return true. */
     virtual bool supportsNoteName() const noexcept { return false; }
 
@@ -226,6 +229,7 @@ struct clap_juce_audio_processor_capabilities
     {
         return false;
     }
+#endif
 
     /** Plugins should call this method when their note names have changed. */
     void noteNamesChanged()

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1076,7 +1076,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             {
                 const auto optionalNoteName = processor->getNameForMidiNoteNumber (key, channel + 1);
                 if (optionalNoteName.has_value())
-                    noteNameInfoCached.emplace_back (*optionalNoteName, (int16_t) key, (int16_t) channel);
+                    noteNameInfoCached.push_back ({ *optionalNoteName, (int16_t) key, (int16_t) channel });
             }
         }
 

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -684,6 +684,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
     bool supressParameterChangeMessages{false};
     void audioProcessorParameterChanged(juce::AudioProcessor *, int index, float newValue) override
     {
+#if 0 // PARAM_LISTENERS_ON_MAIN_THREAD
         if (cacheHostCanUseThreadCheck)
         {
             // Parameter change messages should not be coming from the audio thread!
@@ -695,6 +696,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 return;
             }
         }
+#endif
 
         // This change message came from an event that we've already handled.
         // Let's return here to avoid creating a feedback loop!
@@ -1053,6 +1055,47 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         return Plugin::voiceInfoGet(info);
     }
 
+#if JUCE_VERSION >= 0x080005
+    bool implementsNoteName() const noexcept override
+    {
+        return true;
+    }
+
+    uint32_t noteNameCount() noexcept override
+    {
+        noteNameInfoCached.clear();
+
+        // The JUCE docs say that plugins need to be able to handle
+        // note name requests for notes above 127, but CLAP only supports
+        // notes in range [0, 127].
+        for (int key = 0; key < 128; ++key)
+        {
+            // JUCE expects MIDI channels in range [1, 16].
+            // CLAP expects MIDI channels in range [0, 15].
+            for (int channel = 0; channel < 16; ++channel)
+            {
+                const auto optionalNoteName = processor->getNameForMidiNoteNumber (key, channel + 1);
+                if (optionalNoteName.has_value())
+                    noteNameInfoCached.emplace_back (*optionalNoteName, (int16_t) key, (int16_t) channel);
+            }
+        }
+
+        return static_cast<uint32_t> (noteNameInfoCached.size());
+    }
+
+    bool noteNameGet(uint32_t index, clap_note_name *noteName) noexcept override
+    {
+        if (index >= noteNameInfoCached.size())
+            return false;
+
+        const auto& noteNameInfo = noteNameInfoCached[index];
+        noteNameInfo.name.copyToUTF8 (noteName->name, CLAP_NAME_SIZE);
+        noteName->key = noteNameInfo.key;
+        noteName->channel = noteNameInfo.channel;
+        noteName->port = -1;
+        return true;
+    }
+#else
     bool implementsNoteName() const noexcept override
     {
         if (processorAsClapExtensions)
@@ -1073,6 +1116,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             return processorAsClapExtensions->noteNameGet(index, noteName);
         return false;
     }
+#endif
 
     bool implementsTrackInfo() const noexcept override { return true; }
 
@@ -2305,6 +2349,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             return false;
         }
 
+        if (chunkMemory.isEmpty())
+            return false;
+
         // JUCE has no way to report an unstream error; setStateInformation is void
         // So we just have to assume it works.
         processor->setStateInformation(chunkMemory.getData(), (int)chunkMemory.getSize());
@@ -2387,6 +2434,14 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
 
     const clap_event_transport *transportInfo{nullptr};
     bool hasTransportInfo{false};
+
+    struct NoteNameInfo
+    {
+        juce::String name {};
+        int16_t key = -1;
+        int16_t channel = -1;
+    };
+    std::vector<NoteNameInfo> noteNameInfoCached {};
 };
 
 JUCE_END_IGNORE_WARNINGS_GCC_LIKE

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -2349,7 +2349,8 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
             return false;
         }
 
-        if (chunkMemory.isEmpty())
+        // On newer JUCE versions we can use chunkMemory.isEmpty(), but older JUCE didn't have that
+        if (chunkMemory.getSize() == 0)
             return false;
 
         // JUCE has no way to report an unstream error; setStateInformation is void


### PR DESCRIPTION
Resolves #158.

For JUCE 8.0.5 and above, have CJE use JUCE's note name mechanism rather than our own. This implementation works but there's a couple of things worth noting.

- The JUCE approach does not allow us to ask the plugin how many note names the plugin provides, which is something the CLAP extension expects. As a result, the code I've implemented in the wrapper creates a "cache" of note names when the host asks how many note names the plugin has. Then when the hosts asks for a specific note name, we can just return the value from the cache. However, if the host asks for the number of note names more than once, we end up re-building the cache for no reason. This hasn't happened yet in my testing with Bitwig and Reaper.
- The JUCE approach does not have a way for the plugin to tell the host that the note names have changed, so I've left the extension code that handles that in place for now.

If anyone has ideas for improving these things, that would be great!

This PR also has a couple of one-line changes that were causing issues in clap-validator.