### PR TITLE
Allowing custom override for JUCE-style note names

### DIFF
--- a/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.cpp
@@ -56,17 +56,17 @@ std::optional<juce::String> NoteNamesPlugin::getNameForMidiNoteNumber (int noteN
     return std::nullopt;
 }
 #else
-int NoteNamesPlugin::noteNameCount() noexcept
+uint32_t NoteNamesPlugin::noteNameCount() noexcept
 {
     const auto noteNamesIndex = static_cast<size_t>(noteNamesParam->load());
-    return (int)noteMaps[noteNamesIndex].size();
+    return static_cast<uint32_t>(noteMaps[noteNamesIndex].size());
 }
 
-bool NoteNamesPlugin::noteNameGet(int index, clap_note_name *noteName) noexcept
+bool NoteNamesPlugin::noteNameGet(uint32_t index, clap_note_name *noteName) noexcept
 {
     const auto noteNamesIndex = static_cast<size_t>(noteNamesParam->load());
     const auto &noteMap = noteMaps[noteNamesIndex];
-    if (index < (int)noteMap.size())
+    if (index < noteMap.size())
     {
         const auto &note = noteMap[(size_t)index];
         strcpy(noteName->name, note.name.getCharPointer());

--- a/examples/NoteNamesPlugin/NoteNamesPlugin.h
+++ b/examples/NoteNamesPlugin/NoteNamesPlugin.h
@@ -17,8 +17,8 @@ class NoteNamesPlugin : public juce::AudioProcessor,
     std::optional<juce::String> getNameForMidiNoteNumber (int note, int midiChannel) override;
 #else
     bool supportsNoteName() const noexcept override { return true; }
-    int noteNameCount() noexcept override;
-    bool noteNameGet(int index, clap_note_name *noteName) noexcept override;
+    uint32_t noteNameCount() noexcept override;
+    bool noteNameGet(uint32_t index, clap_note_name *noteName) noexcept override;
 #endif
 
     const juce::String getName() const override { return JucePlugin_Name; }

--- a/include/clap-juce-extensions/clap-juce-extensions.h
+++ b/include/clap-juce-extensions/clap-juce-extensions.h
@@ -210,10 +210,11 @@ struct clap_juce_audio_processor_capabilities
     virtual bool prefersNoteDialectClap(bool isInput) { return supportsNoteDialectClap(isInput); }
 
     // JUCE added support for note names in juce::AudioProcessor
-    // in version 8.0.5, so we don't need these methods anymore.
-#if JUCE_VERSION < 0x080005
+    // in version 8.0.5, but we still allow users to implement
+    // CLAP-style note names if they want to.
+
     /** If your plugin supports custom note names, then override this method to return true. */
-    virtual bool supportsNoteName() const noexcept { return false; }
+    [[nodiscard]] virtual bool supportsNoteName() const noexcept { return false; }
 
     /**
      * If your plugin supports custom note names, then this method should be overriden
@@ -229,7 +230,6 @@ struct clap_juce_audio_processor_capabilities
     {
         return false;
     }
-#endif
 
     /** Plugins should call this method when their note names have changed. */
     void noteNamesChanged()


### PR DESCRIPTION
Patrick on the CLAP Discord pointed out that we might want to allow users to "override" the JUCE's note name mechanism, and interface directly with CLAP's note name mechanism instead. So with this PR, if the plugin implements `clap_juce_audio_processor_capabilities::supportsNoteName()` and has it return true, then the CLAP wrapper will use the `clap_juce_audio_processor_capabilities` note name methods, rather than the JUCE note name method.