### PR TITLE
Move Posix FD to READ (POLLIN) only

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -587,8 +587,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
         {
             for (auto &fd : registeredFDs)
             {
-                _host.posixFdSupportRegister(fd, CLAP_POSIX_FD_READ | CLAP_POSIX_FD_WRITE |
-                                                     CLAP_POSIX_FD_ERROR);
+                _host.posixFdSupportRegister(fd, CLAP_POSIX_FD_READ);
             }
         }
     }


### PR DESCRIPTION
We bound all three, and in some situations in bitwig that would cause a runaway cpu in the ui thread