### PR TITLE
Fix keyboard input in embedded plugin editors on Windows

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -20,6 +20,10 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
 
+#if JUCE_WINDOWS
+#include <juce_gui_basics/native/juce_WindowsHooks_windows.h>
+#endif
+
 #if JUCE_VERSION >= 0x070006
 #include <juce_audio_plugin_client/detail/juce_IncludeSystemHeaders.h>
 #include <juce_audio_plugin_client/detail/juce_PluginUtilities.h>
@@ -1967,6 +1971,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
       private:
         juce::Rectangle<int> lastBounds;
         bool resizingChild = false, resizingParent = false;
+#if JUCE_WINDOWS
+        juce::detail::WindowsHooks hooks;
+#endif
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EditorWrapperComponent)
     };
     std::unique_ptr<EditorWrapperComponent> editorWrapper;

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -20,7 +20,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
 
-#if JUCE_WINDOWS
+#if JUCE_WINDOWS && JUCE_VERSION >= 0x070006
 #include <juce_gui_basics/native/juce_WindowsHooks_windows.h>
 #endif
 
@@ -1971,7 +1971,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
       private:
         juce::Rectangle<int> lastBounds;
         bool resizingChild = false, resizingParent = false;
-#if JUCE_WINDOWS
+#if JUCE_WINDOWS && JUCE_VERSION >= 0x070006
         juce::detail::WindowsHooks hooks;
 #endif
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EditorWrapperComponent)


### PR DESCRIPTION
## Summary

Add `juce::detail::WindowsHooks` to the CLAP wrapper's `EditorWrapperComponent`, matching the pattern used by JUCE's VST2, VST3, and AAX plugin client wrappers.

## Problem

On Windows, text input fields in CLAP plugin editors may exhibit cursor jumping, character reordering, and other input corruption. For example, typing "46" into a numeric field may produce "64".

## Reproducibility

This issue does not manifest on every system. In our testing, we observed it consistently on some Windows 11 machines running Bitwig with DPI scaling > 100%, while other near-identical setups at 100% DPI showed no problems. The fix resolved the issue on all affected machines without introducing regressions on unaffected ones. We were unable to determine the exact conditions that trigger the bug beyond the missing hook, but the underlying cause (missing WindowsHooks) affects all Windows CLAP hosts in theory.

## Root Cause

JUCE's VST2, VST3, and AAX wrappers all instantiate `juce::detail::WindowsHooks`, which installs a `WH_GETMESSAGE` keyboard hook. This hook intercepts keyboard messages *before* the host's message loop via `offerKeyMessageToJUCEWindow`, allowing JUCE to process keystrokes directly.

Without this hook, keyboard messages go through the host's normal dispatch path. When `doKeyDown` doesn't fully consume a keystroke, `forwardMessageToParent` posts the `WM_KEYDOWN` back to the host window. The host may then re-dispatch it to the plugin, causing double processing and input corruption.

The CLAP wrapper was the only format missing this hook.

## Fix

- Include `juce_WindowsHooks_windows.h` (Windows only)
- Add `juce::detail::WindowsHooks hooks` member to `EditorWrapperComponent` (Windows only)

Unconsumed keystrokes are still forwarded to the host correctly — the hook only intercepts when JUCE actually handles the key.