### PR TITLE
Allow sending 2 byte messages (program & channel AT) in outbound MIDI

### DIFF
--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1816,7 +1816,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 for (auto meta : midiBuffer)
                 {
                     auto msg = meta.getMessage();
-                    auto msgSize = msg.getRawDataSize();
+                    size_t msgSize = msg.getRawDataSize();
                     if (msgSize == 2 || msgSize == 3)
                     {
                         auto evt = clap_event_midi();

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1816,7 +1816,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 for (auto meta : midiBuffer)
                 {
                     auto msg = meta.getMessage();
-                    size_t msgSize = msg.getRawDataSize();
+                    auto msgSize = msg.getRawDataSize();
                     if (msgSize == 2 || msgSize == 3)
                     {
                         auto evt = clap_event_midi();

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1826,7 +1826,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                         evt.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
                         evt.header.flags = 0;
                         evt.port_index = 0;
-                        memcpy(&evt.data, msg.getRawData(), msgSize * sizeof(uint8_t));
+                        memcpy(&evt.data, msg.getRawData(), static_cast<size_t>(msgSize) * sizeof(uint8_t));
                         if (msgSize == 2) {
                           evt.data[2] = 0;
                         }

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1816,6 +1816,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 for (auto meta : midiBuffer)
                 {
                     auto msg = meta.getMessage();
+                    auto msgSize = msg.getRawDataSize();
                     if (msgSize == 2 || msgSize == 3)
                     {
                         auto evt = clap_event_midi();

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1816,7 +1816,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                 for (auto meta : midiBuffer)
                 {
                     auto msg = meta.getMessage();
-                    if (msg.getRawDataSize() == 3)
+                    if (msgSize == 2 || msgSize == 3)
                     {
                         auto evt = clap_event_midi();
                         evt.header.size = sizeof(clap_event_midi);
@@ -1825,7 +1825,7 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                         evt.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
                         evt.header.flags = 0;
                         evt.port_index = 0;
-                        memcpy(&evt.data, msg.getRawData(), 3 * sizeof(uint8_t));
+                        memcpy(&evt.data, msg.getRawData(), msgSize * sizeof(uint8_t));
                         ov->try_push(ov, reinterpret_cast<const clap_event_header *>(&evt));
                     }
                 }

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -1826,6 +1826,9 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
                         evt.header.flags = 0;
                         evt.port_index = 0;
                         memcpy(&evt.data, msg.getRawData(), msgSize * sizeof(uint8_t));
+                        if (msgSize == 2) {
+                          evt.data[2] = 0;
+                        }
                         ov->try_push(ov, reinterpret_cast<const clap_event_header *>(&evt));
                     }
                 }


### PR DESCRIPTION
When sending outbound MIDI, the wrapper was only allowing messages with 3 byte length. This means program changes and channel aftertouch don't get output from the plugin. I'm working on a note effect plugin that outputs program changes and ran into this for my use case.

Tested this update in a CLAP note effect plugin sending its output into another CLAP plugin that responds to program changes. Tested on Reaper, Bitwig, and FL Studio on macOS (ARM), and Reaper on Windows (x64).