### PR TITLE
JUCE 9 support

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -57,7 +57,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt install libasound2-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libfreetype6-dev libfontconfig1-dev libglu1-mesa-dev libjack-jackd2-dev
+          sudo apt install libasound2-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxrandr-dev libxrender-dev libfreetype6-dev libfontconfig1-dev libglu1-mesa-dev libjack-jackd2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11
 

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -31,6 +31,8 @@ jobs:
             juce_version: 8.0.10
           - os: ubuntu-22.04
             juce_version: 8.0.11
+          - os: ubuntu-22.04
+            juce_version: 9.0.0
 
           - os: windows-latest
             juce_version: 6.1.6
@@ -42,9 +44,13 @@ jobs:
             juce_version: 8.0.10
           - os: windows-latest
             juce_version: 8.0.11
+          - os: windows-latest
+            juce_version: 9.0.0
 
           - os: macOS-latest
             juce_version: 8.0.11
+          - os: macOS-latest
+            juce_version: 9.0.0
 
     steps:
       - name: Install Linux Deps

--- a/src/wrapper/clap-juce-wrapper.cpp
+++ b/src/wrapper/clap-juce-wrapper.cpp
@@ -2455,9 +2455,16 @@ class ClapJuceWrapper : public clap::helpers::Plugin<
 #if JUCE_VERSION < 0x070006
         juce::initialiseMacVST();
         auto hostWindow = juce::attachComponentToWindowRefVST(editorWrapper.get(), nsView, true);
-#else
+#elif JUCE_VERSION < 0x090000
         const auto desktopFlags =
             juce::detail::PluginUtilities::getDesktopFlags(editorWrapper->editor.get());
+        auto hostWindow = juce::detail::VSTWindowUtilities::attachComponentToWindowRefVST(
+            editorWrapper.get(), desktopFlags, nsView);
+#else
+        const auto desktopFlags =
+            juce::detail::PluginUtilities::getDesktopFlagsAndWindowsMultiTouchMode(
+                editorWrapper->editor.get())
+                .desktopFlags;
         auto hostWindow = juce::detail::VSTWindowUtilities::attachComponentToWindowRefVST(
             editorWrapper.get(), desktopFlags, nsView);
 #endif


### PR DESCRIPTION
JUCE 9 renamed `getDesktopFlags` to `getDesktopFlagsAndWindowsMultiTouchMode`

Also adds JUCE 9.0.0. to CI and `libxi-dev` as an additional Linux CI dependency for XInput.